### PR TITLE
Make make more silent in case of generated docs directory does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -325,7 +325,7 @@ deepcopy-gen: ## Generate deepcopy golang code
 	operator-sdk generate k8s
 
 .PHONY: scheme-doc-gen
-HAS_GEN_CRD_API_REFERENCE_DOCS := $(shell ls gen-crd-api-reference-docs)
+HAS_GEN_CRD_API_REFERENCE_DOCS := $(shell ls gen-crd-api-reference-docs 2> /dev/null)
 scheme-doc-gen: ## Generate Jenkins CRD scheme doc
 	@echo "+ $@"
 ifndef HAS_GEN_CRD_API_REFERENCE_DOCS


### PR DESCRIPTION
Hi team,

this is a small PR to make `make build`more silent in case of generated docs directory does not exist.
Currently it displays an error which is a bit confusing.
