### PR TITLE
Force building of operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -318,6 +318,7 @@ minikube-run: export WATCH_NAMESPACE = $(NAMESPACE)
 minikube-run: export OPERATOR_NAME = $(NAME)
 minikube-run: minikube-start build ## Run the operator locally and use minikube as Kubernetes cluster, you can use EXTRA_ARGS
 	@echo "+ $@"
+	make build
 	kubectl config use-context minikube
 	kubectl apply -f deploy/crds/jenkins_$(API_VERSION)_jenkins_crd.yaml
 	@echo "Watching '$(WATCH_NAMESPACE)' namespace"


### PR DESCRIPTION
If developer tries to run operator locally by command: "make minikube-run EXTRA_ARGS='--minikube --local'" and won't build project then may encounter error. So, I have added command "make build" to Makefile to build automatically when minikube-run command is being executed.