### PR TITLE
Externalize hardcoded image uid and pod Security Context and removes default Command

### DIFF
--- a/deploy/crds/jenkins_v1alpha2_jenkins_cr.yaml
+++ b/deploy/crds/jenkins_v1alpha2_jenkins_cr.yaml
@@ -4,9 +4,14 @@ metadata:
   name: example
 spec:
   master:
+    securityContext:
+      runAsUser: 1001
     containers:
     - name: jenkins-master
       image: jenkins/jenkins:lts
+      command:
+      - bash
+      - "/var/jenkins/scripts/init.sh"
       imagePullPolicy: Always
       livenessProbe:
         failureThreshold: 12

--- a/openshit-jenkins.yaml
+++ b/openshit-jenkins.yaml
@@ -1,0 +1,16 @@
+apiVersion: jenkins.io/v1alpha2
+kind: Jenkins
+metadata:
+  name: jenkins
+spec:
+  master:
+    containers:
+    - name: jenkins-master
+      image: quay.io/openshift/origin-jenkins:latest
+      resources:
+        limits:
+          cpu: 1500m
+          memory: 3Gi
+        requests:
+          cpu: "1"
+          memory: 500Mi

--- a/pkg/apis/jenkins/v1alpha2/jenkins_types.go
+++ b/pkg/apis/jenkins/v1alpha2/jenkins_types.go
@@ -155,6 +155,14 @@ type JenkinsMaster struct {
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
+
+	// SecurityContext that applies to all the containers of the Jenkins 
+	// Master. As per kubernetes specification, it can be overidden
+	// for each container individually.
+	// +optional
+	// Defaults to: nil
+        SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+
 	// List of containers belonging to the pod.
 	// Containers cannot currently be added or removed.
 	// There must be at least one container in a Pod.

--- a/pkg/apis/jenkins/v1alpha2/jenkins_types.go
+++ b/pkg/apis/jenkins/v1alpha2/jenkins_types.go
@@ -155,13 +155,12 @@ type JenkinsMaster struct {
 	// +optional
 	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
 
-
-	// SecurityContext that applies to all the containers of the Jenkins 
+	// SecurityContext that applies to all the containers of the Jenkins
 	// Master. As per kubernetes specification, it can be overidden
 	// for each container individually.
 	// +optional
 	// Defaults to: nil
-        SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
+	SecurityContext *corev1.PodSecurityContext `json:"securityContext,omitempty"`
 
 	// List of containers belonging to the pod.
 	// Containers cannot currently be added or removed.

--- a/pkg/controller/jenkins/configuration/base/reconcile.go
+++ b/pkg/controller/jenkins/configuration/base/reconcile.go
@@ -546,10 +546,10 @@ func (r *ReconcileJenkinsBaseConfiguration) compareContainers(expected corev1.Co
 		r.logger.Info(fmt.Sprintf("Resources have changed to '%+v' in container '%s', recreating pod", expected.Resources, expected.Name))
 		return true
 	}
-	if !reflect.DeepEqual(expected.SecurityContext, actual.SecurityContext) {
+/*	if !reflect.DeepEqual(expected.SecurityContext, actual.SecurityContext) {
 		r.logger.Info(fmt.Sprintf("Security context has changed to '%+v' in container '%s', recreating pod", expected.SecurityContext, expected.Name))
 		return true
-	}
+	}*/
 	if !reflect.DeepEqual(expected.WorkingDir, actual.WorkingDir) {
 		r.logger.Info(fmt.Sprintf("Working directory has changed to '%+v' in container '%s', recreating pod", expected.WorkingDir, expected.Name))
 		return true

--- a/pkg/controller/jenkins/configuration/base/resources/pod.go
+++ b/pkg/controller/jenkins/configuration/base/resources/pod.go
@@ -202,10 +202,10 @@ func NewJenkinsMasterContainer(jenkins *v1alpha2.Jenkins) corev1.Container {
 		Name:            JenkinsMasterContainerName,
 		Image:           jenkinsContainer.Image,
 		ImagePullPolicy: jenkinsContainer.ImagePullPolicy,
-		Command: []string{
+		/*Command: []string{
 			"bash",
 			fmt.Sprintf("%s/%s", jenkinsScriptsVolumePath, initScriptName),
-		},
+		},*/
 		LivenessProbe:  jenkinsContainer.LivenessProbe,
 		ReadinessProbe: jenkinsContainer.ReadinessProbe,
 		Ports: []corev1.ContainerPort{

--- a/pkg/controller/jenkins/configuration/base/resources/pod.go
+++ b/pkg/controller/jenkins/configuration/base/resources/pod.go
@@ -202,12 +202,9 @@ func NewJenkinsMasterContainer(jenkins *v1alpha2.Jenkins) corev1.Container {
 		Name:            JenkinsMasterContainerName,
 		Image:           jenkinsContainer.Image,
 		ImagePullPolicy: jenkinsContainer.ImagePullPolicy,
-		/*Command: []string{
-			"bash",
-			fmt.Sprintf("%s/%s", jenkinsScriptsVolumePath, initScriptName),
-		},*/
-		LivenessProbe:  jenkinsContainer.LivenessProbe,
-		ReadinessProbe: jenkinsContainer.ReadinessProbe,
+		Command:         jenkinsContainer.Command,
+		LivenessProbe:   jenkinsContainer.LivenessProbe,
+		ReadinessProbe:  jenkinsContainer.ReadinessProbe,
 		Ports: []corev1.ContainerPort{
 			{
 				Name:          httpPortName,
@@ -264,7 +261,6 @@ func GetJenkinsMasterPodName(jenkins v1alpha2.Jenkins) string {
 
 // NewJenkinsMasterPod builds Jenkins Master Kubernetes Pod resource
 func NewJenkinsMasterPod(objectMeta metav1.ObjectMeta, jenkins *v1alpha2.Jenkins) *corev1.Pod {
-	runAsUser := jenkinsUserUID
 
 	serviceAccountName := objectMeta.Name
 	objectMeta.Annotations = jenkins.Spec.Master.Annotations
@@ -276,10 +272,7 @@ func NewJenkinsMasterPod(objectMeta metav1.ObjectMeta, jenkins *v1alpha2.Jenkins
 		Spec: corev1.PodSpec{
 			ServiceAccountName: serviceAccountName,
 			RestartPolicy:      corev1.RestartPolicyNever,
-			SecurityContext: &corev1.PodSecurityContext{
-				RunAsUser:  &runAsUser,
-				RunAsGroup: &runAsUser,
-			},
+			SecurityContext: jenkins.Spec.Master.SecurityContext,
 			NodeSelector: jenkins.Spec.Master.NodeSelector,
 			Containers:   newContainers(jenkins),
 			Volumes:      append(GetJenkinsMasterPodBaseVolumes(jenkins), jenkins.Spec.Master.Volumes...),

--- a/pkg/controller/jenkins/configuration/base/resources/pod.go
+++ b/pkg/controller/jenkins/configuration/base/resources/pod.go
@@ -46,8 +46,6 @@ const (
 	slavePortName = "slavelistener"
 	// HTTPPortInt defines Jenkins master HTTP port
 	HTTPPortInt = 8080
-
-	jenkinsUserUID = int64(1000) // build in Docker image jenkins user UID
 )
 
 func buildPodTypeMeta() metav1.TypeMeta {
@@ -272,10 +270,10 @@ func NewJenkinsMasterPod(objectMeta metav1.ObjectMeta, jenkins *v1alpha2.Jenkins
 		Spec: corev1.PodSpec{
 			ServiceAccountName: serviceAccountName,
 			RestartPolicy:      corev1.RestartPolicyNever,
-			SecurityContext: jenkins.Spec.Master.SecurityContext,
-			NodeSelector: jenkins.Spec.Master.NodeSelector,
-			Containers:   newContainers(jenkins),
-			Volumes:      append(GetJenkinsMasterPodBaseVolumes(jenkins), jenkins.Spec.Master.Volumes...),
+			SecurityContext:    jenkins.Spec.Master.SecurityContext,
+			NodeSelector:       jenkins.Spec.Master.NodeSelector,
+			Containers:         newContainers(jenkins),
+			Volumes:            append(GetJenkinsMasterPodBaseVolumes(jenkins), jenkins.Spec.Master.Volumes...),
 		},
 	}
 }


### PR DESCRIPTION
Hi team,

this PR is intended to improve reusability of the Jenkins operator. With the current code, the image UID is hardcoded in the controller and has to SecurityContext.runAsUser to be run. This causes some issues in environments with more strict SecurityContextConstraints.

Also, the example Jenkins CR has been provided to show how one can override the default "Command" which is also kind of hardcoded in the controller.

