### PR TITLE
Filter for valid backups before trying to remove them

### DIFF
--- a/backup/pvc/bin/run.sh
+++ b/backup/pvc/bin/run.sh
@@ -10,6 +10,6 @@ do
     sleep 10
     if [[ ! -z "${BACKUP_COUNT}" ]]; then
         echo "Trimming to only ${BACKUP_COUNT} recent backups in preparation for new backup"
-        ls ${BACKUP_DIR} | sort -gr | tail -n +$((BACKUP_COUNT +1)) | xargs -I '{}' rm ${BACKUP_DIR}/'{}'
+        ls ${BACKUP_DIR} | sort -gr | grep 'tar.gz' | tail -n +$((BACKUP_COUNT +1)) | xargs -I '{}' rm ${BACKUP_DIR}/'{}'
     fi
 done

--- a/backup/pvc/e2e/limit_backup_count/test.sh
+++ b/backup/pvc/e2e/limit_backup_count/test.sh
@@ -17,6 +17,7 @@ JENKINS_HOME="$(pwd)/jenkins_home"
 BACKUP_DIR="$(pwd)/backup"
 mkdir -p ${BACKUP_DIR}
 
+mkdir -p ${BACKUP_DIR}/lost+found
 touch ${BACKUP_DIR}/1.tar.gz
 touch ${BACKUP_DIR}/2.tar.gz
 touch ${BACKUP_DIR}/3.tar.gz
@@ -46,7 +47,7 @@ if [[ "${DEBUG}" ]]; then
 fi
 
 # only two latest backup should exists
-[[ $(ls -1 ${BACKUP_DIR} | wc -l) -eq 2 ]] || exit 1
+[[ $(ls -1 ${BACKUP_DIR} | grep 'tar.gz' | wc -l) -eq 2 ]] || exit 1
 [[ -f ${BACKUP_DIR}/11.tar.gz ]] || exit 2
 [[ -f ${BACKUP_DIR}/12.tar.gz ]] || exit 3
 echo PASS


### PR DESCRIPTION
In our testing we ran into an issue testing the backup utility. The `backup` container was crashing due to the failing `rm` command as it encountered a `lost+found` directory in our `pvc`.

This PR adds a `grep` command to filter out only valid backup files so only these are scheduled for removal allowing the container to finish gracefully.