### PR TITLE
Support no backup file case.

### DIFF
--- a/backup/pvc/bin/run.sh
+++ b/backup/pvc/bin/run.sh
@@ -10,6 +10,6 @@ do
     sleep 10
     if [[ ! -z "${BACKUP_COUNT}" ]]; then
         echo "Trimming to only ${BACKUP_COUNT} recent backups in preparation for new backup"
-        ls ${BACKUP_DIR} | sort -gr | grep 'tar.gz' | tail -n +$((BACKUP_COUNT +1)) | xargs -I '{}' rm ${BACKUP_DIR}/'{}'
+        find ${BACKUP_DIR} -name '*.tar.gz' -exec basename {} \; | sort -gr | tail -n +$((BACKUP_COUNT +1)) | xargs -I '{}' rm ${BACKUP_DIR}/'{}'
     fi
 done


### PR DESCRIPTION
If there is no backup file then `grep` exit with nonzero code.
So use `find` instead of it.