### PR TITLE
change plugin name regex to case-insensitive.

### DIFF
--- a/pkg/controller/jenkins/plugins/plugin.go
+++ b/pkg/controller/jenkins/plugins/plugin.go
@@ -22,7 +22,7 @@ func (p Plugin) String() string {
 }
 
 var (
-	namePattern    = regexp.MustCompile(`^[0-9a-z-_]+$`)
+	namePattern    = regexp.MustCompile(`(?i)^[0-9a-z-_]+$`)
 	versionPattern = regexp.MustCompile(`^[0-9\\.]+$`)
 )
 

--- a/pkg/controller/jenkins/plugins/plugin_test.go
+++ b/pkg/controller/jenkins/plugins/plugin_test.go
@@ -44,6 +44,18 @@ func TestVerifyDependencies(t *testing.T) {
 		got := VerifyDependencies(basePlugins)
 		assert.Equal(t, true, got)
 	})
+    t.Run("happy, two plugin names with uppercase names", func(t *testing.T) {
+        basePlugins := map[Plugin][]Plugin{
+            Must(New("First-Root-Plugin:1.0.0")): {
+                Must(New("First_Plugin:0.0.1")),
+            },
+            Must(New("Second_Root_Plugin:1.0.0")): {
+                Must(New("First_Plugin:0.0.1")),
+            },
+        }
+        got := VerifyDependencies(basePlugins)
+        assert.Equal(t, true, got)
+    })
 	t.Run("fail, two root plugins have different versions", func(t *testing.T) {
 		basePlugins := map[Plugin][]Plugin{
 			Must(New("first-root-plugin:1.0.0")): {


### PR DESCRIPTION
Upper/Camel case is a valid plugin name in jenkins, this change is adding the insensitive flag to the plugin name validation in order to accept such plugins.

fix #109 