### PR TITLE
Updating plugin.go to allow versions

### DIFF
--- a/pkg/controller/jenkins/configuration/base/validate_test.go
+++ b/pkg/controller/jenkins/configuration/base/validate_test.go
@@ -57,7 +57,7 @@ func TestValidatePlugins(t *testing.T) {
 
 		got := baseReconcileLoop.validatePlugins(requiredBasePlugins, basePlugins, userPlugins)
 
-		assert.Equal(t, got, []string{"invalid plugin version 'simple-plugin:invalid', must follow pattern '^[0-9\\\\.-]+$'"})
+		assert.Equal(t, got, []string{"invalid plugin version 'simple-plugin:invalid', must follow pattern '^[0-9\\\\.-]+(\\..+)?$'"})
 	})
 	t.Run("valid base plugin", func(t *testing.T) {
 		var requiredBasePlugins []plugins.Plugin
@@ -84,7 +84,7 @@ func TestValidatePlugins(t *testing.T) {
 
 		got := baseReconcileLoop.validatePlugins(requiredBasePlugins, basePlugins, userPlugins)
 
-		assert.Equal(t, got, []string{"invalid plugin version 'simple-plugin:invalid', must follow pattern '^[0-9\\\\.-]+$'"})
+		assert.Equal(t, got, []string{"invalid plugin version 'simple-plugin:invalid', must follow pattern '^[0-9\\\\.-]+(\\..+)?$'"})
 	})
 	t.Run("valid user and base plugin version", func(t *testing.T) {
 		var requiredBasePlugins []plugins.Plugin

--- a/pkg/controller/jenkins/plugins/plugin.go
+++ b/pkg/controller/jenkins/plugins/plugin.go
@@ -21,7 +21,7 @@ func (p Plugin) String() string {
 
 var (
 	namePattern    = regexp.MustCompile(`(?i)^[0-9a-z-_]+$`)
-	versionPattern = regexp.MustCompile(`^[0-9\\.-]+$`)
+	versionPattern = regexp.MustCompile(`^[0-9\\.-]+(\..+)?$`)
 )
 
 // New creates plugin from string, for example "name-of-plugin:0.0.1"


### PR DESCRIPTION
This change is it allow all possible versions in all plugins within update.jenkins.io, this is linked to issue:https://github.com/jenkinsci/kubernetes-operator/issues/144