### PR TITLE
Adding AgentDetails to be optional

### DIFF
--- a/pkg/apis/jenkins/v1alpha2/jenkins_types.go
+++ b/pkg/apis/jenkins/v1alpha2/jenkins_types.go
@@ -310,6 +310,9 @@ type JenkinsMaster struct {
 	// Plugins contains plugins required by user
 	// +optional
 	Plugins []Plugin `json:"plugins,omitempty"`
+
+        //BuildersServiceAccountName Name of the SA bound to the builder
+	BuilderServiceAccountName string `json:"builderServiceAccountName,omitempty"`
 }
 
 // Service defines Kubernetes service attributes

--- a/pkg/apis/jenkins/v1alpha2/jenkins_types.go
+++ b/pkg/apis/jenkins/v1alpha2/jenkins_types.go
@@ -52,6 +52,10 @@ type JenkinsSpec struct {
 	// ConfigurationAsCode defines configuration of Jenkins customization via Configuration as Code Jenkins plugin
 	// +optional
 	ConfigurationAsCode ConfigurationAsCode `json:"configurationAsCode,omitempty"`
+
+	// Agent defines configuration of the build Agents
+	// +optional
+        Agent Agent `json:"agent,omitempty"`
 }
 
 // NotificationLogLevel defines logging level of Notification
@@ -214,6 +218,15 @@ type Plugin struct {
 	Version string `json:"version"`
 }
 
+// Plugin defines Jenkins agent
+type Agent struct {
+	// Name is the name of Jenkins Agent
+	Name string `json:"name"`
+	// Image to be used for the Jenkins Agent
+	Image string `json:"image"`
+	// ServiceAccountName to be used on the Jenins Agent
+	ServiceAccountName string `json:"serviceAccountName"`
+}
 // JenkinsMaster defines the Jenkins master pod attributes and plugins,
 // every single change requires a Jenkins master pod restart
 type JenkinsMaster struct {

--- a/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs.go
+++ b/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs.go
@@ -393,6 +393,7 @@ func agentDeployment(jenkins *v1alpha2.Jenkins, namespace string, agentName stri
 							},
 						},
 					},
+                                        ServiceAccountName: jenkins.Spec.Master.BuilderServiceAccountName,
 				},
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{

--- a/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs_test.go
+++ b/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs_test.go
@@ -86,7 +86,7 @@ func TestEnsureSeedJobs(t *testing.T) {
 			},
 		}
 
-		seedJobCreatingScript, err := seedJobCreatingGroovyScript(jenkins.Spec.SeedJobs[0])
+		seedJobCreatingScript, err := seedJobCreatingGroovyScript(jenkins.Spec.SeedJobs[0],jenkins)
 		assert.NoError(t, err)
 
 		jenkinsClient.EXPECT().GetNode(AgentName).Return(nil, nil).AnyTimes()
@@ -158,6 +158,7 @@ func TestCreateAgent(t *testing.T) {
 
 		agentSecret := "test-secret"
 		jenkins := jenkinsCustomResource()
+                agentDetails := getAgentDetails(jenkins)
 
 		jenkinsClient := jenkinsclient.NewMockJenkins(ctrl)
 		fakeClient := fake.NewFakeClient()
@@ -179,7 +180,7 @@ func TestCreateAgent(t *testing.T) {
 		assert.NoError(t, err)
 
 		// when
-		err = seedJobsClient.createAgent(jenkinsClient, fakeClient, jenkinsCustomResource(), jenkins.Namespace, AgentName)
+		err = seedJobsClient.createAgent(jenkinsClient, fakeClient, jenkinsCustomResource(), jenkins.Namespace, agentDetails)
 
 		// then
 		assert.NoError(t, err)


### PR DESCRIPTION
Hi Guys.

This is sort of the proposal in relevance to the ticket:
https://github.com/jenkinsci/kubernetes-operator/issues/159

The idea is that the user could set the ServiceAccount that the builder will run on as:
```
apiVersion: jenkins.io/v1alpha2    
kind: Jenkins    
metadata:    
  name: sporting    
spec:    
  agent:    
    name: example    
    image: "jenkins/jnlp-slave:alpine"    
    serviceAccountName: example                                                                                                                                                                                      
  master:                                  
    basePlugins:                           

```
If not set , there's a number of constants that override  them details.

What you think?