### PR TITLE
Add ability to disable CSRFProtection in the Jenkins master

### DIFF
--- a/pkg/apis/jenkins/v1alpha2/jenkins_types.go
+++ b/pkg/apis/jenkins/v1alpha2/jenkins_types.go
@@ -310,6 +310,9 @@ type JenkinsMaster struct {
 	// Plugins contains plugins required by user
 	// +optional
 	Plugins []Plugin `json:"plugins,omitempty"`
+
+	// DisableCSRFProtection allows you to toggle CSRF Protection on Jenkins
+	DisableCSRFProtection bool `json:"disableCSRFProtection"`
 }
 
 // Service defines Kubernetes service attributes


### PR DESCRIPTION
Jenkins Plugin implementations which use PluginServletFilter instead of HudsonFilter invalidate POST requests which are valid. To allow users to be able to use those plugins, this would be a helpful toggle.
 
- CSRF Protection is enabled by default.
- Adding `enableCSRFProtection: false` under `jenkins.spec.master` will disable CSRF protection for the Jenkins instance.
