### PR TITLE
#158 Add ability to configure amount of seed job executors on seed job agent

### DIFF
--- a/pkg/apis/jenkins/v1alpha2/jenkins_types.go
+++ b/pkg/apis/jenkins/v1alpha2/jenkins_types.go
@@ -314,7 +314,7 @@ type JenkinsMaster struct {
 	// DisableCSRFProtection allows you to toggle CSRF Protection on Jenkins
 	DisableCSRFProtection bool `json:"disableCSRFProtection"`
 
-	// SeedJobAgentExecutors is the amount of the seed job agent executors. Default: 1
+	// SeedJobAgentExecutors is the number of the seed job agent executors. Default: 1
 	SeedJobAgentExecutors int `json:"seedJobAgentExecutors"`
 }
 

--- a/pkg/apis/jenkins/v1alpha2/jenkins_types.go
+++ b/pkg/apis/jenkins/v1alpha2/jenkins_types.go
@@ -313,6 +313,9 @@ type JenkinsMaster struct {
 
 	// DisableCSRFProtection allows you to toggle CSRF Protection on Jenkins
 	DisableCSRFProtection bool `json:"disableCSRFProtection"`
+
+	// SeedJobAgentExecutors is the amount of the seed job agent executors. Default: 1
+	SeedJobAgentExecutors int `json:"seedJobAgentExecutors"`
 }
 
 // Service defines Kubernetes service attributes

--- a/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs.go
+++ b/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs.go
@@ -344,7 +344,7 @@ func (s SeedJobs) createAgent(jenkinsClient jenkinsclient.Jenkins, k8sClient cli
 			return err
 		}
 
-		customResourceSeedJobExecutors, err := strconv.Atoi(currentDeployment.Annotations["seedJobExecutorsAmount"])
+		customResourceSeedJobExecutors, err := strconv.Atoi(currentDeployment.Annotations["seedJobExecutorsNumber"])
 		if err != nil {
 			return err
 		}
@@ -382,7 +382,7 @@ func agentDeployment(jenkins *v1alpha2.Jenkins, namespace string, agentName stri
 	return &apps.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
-				"seedJobExecutorsAmount": strconv.Itoa(jenkins.Spec.Master.SeedJobAgentExecutors),
+				"seedJobExecutorsNumber": strconv.Itoa(jenkins.Spec.Master.SeedJobAgentExecutors),
 			},
 			Name:      agentDeploymentName(*jenkins, agentName),
 			Namespace: namespace,

--- a/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs_test.go
+++ b/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs_test.go
@@ -201,7 +201,7 @@ func TestCreateAgent(t *testing.T) {
 		err = fakeClient.Create(ctx, &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					"seedJobExecutorsAmount": "1",
+					"seedJobExecutorsNumber": "1",
 				},
 				Name:      agentDeploymentName(*jenkins, AgentName),
 				Namespace: jenkins.Namespace,

--- a/pkg/controller/jenkins/jenkins_controller.go
+++ b/pkg/controller/jenkins/jenkins_controller.go
@@ -478,12 +478,12 @@ func (r *ReconcileJenkins) setDefaults(jenkins *v1alpha2.Jenkins, logger logr.Lo
 		jenkins.Spec.Master.SecurityContext = &securityContext
 	}
 
-	if jenkins.Spec.Master.SeedJobAgentExecutors < 1 {
-		logger.Info("Setting default seed job agents executors amount")
+	var minimalExecutorsNumber = 1
+	if jenkins.Spec.Master.SeedJobAgentExecutors < minimalExecutorsNumber {
+		logger.Info(fmt.Sprintf("Setting a default minimal seed job agents executors number of: %d", minimalExecutorsNumber))
 		changed = true
-		var defaultExecutorsNumber = 1
 
-		jenkins.Spec.Master.SeedJobAgentExecutors = defaultExecutorsNumber
+		jenkins.Spec.Master.SeedJobAgentExecutors = minimalExecutorsNumber
 	}
 
 	if changed {

--- a/pkg/controller/jenkins/jenkins_controller.go
+++ b/pkg/controller/jenkins/jenkins_controller.go
@@ -478,6 +478,14 @@ func (r *ReconcileJenkins) setDefaults(jenkins *v1alpha2.Jenkins, logger logr.Lo
 		jenkins.Spec.Master.SecurityContext = &securityContext
 	}
 
+	if jenkins.Spec.Master.SeedJobAgentExecutors < 1 {
+		logger.Info("Setting default seed job agents executors amount")
+		changed = true
+		var defaultExecutorsAmount = 1
+
+		jenkins.Spec.Master.SeedJobAgentExecutors = defaultExecutorsAmount
+	}
+
 	if changed {
 		return errors.WithStack(r.client.Update(context.TODO(), jenkins))
 	}

--- a/pkg/controller/jenkins/jenkins_controller.go
+++ b/pkg/controller/jenkins/jenkins_controller.go
@@ -481,9 +481,9 @@ func (r *ReconcileJenkins) setDefaults(jenkins *v1alpha2.Jenkins, logger logr.Lo
 	if jenkins.Spec.Master.SeedJobAgentExecutors < 1 {
 		logger.Info("Setting default seed job agents executors amount")
 		changed = true
-		var defaultExecutorsAmount = 1
+		var defaultExecutorsNumber = 1
 
-		jenkins.Spec.Master.SeedJobAgentExecutors = defaultExecutorsAmount
+		jenkins.Spec.Master.SeedJobAgentExecutors = defaultExecutorsNumber
 	}
 
 	if changed {


### PR DESCRIPTION
* The amount of seed Job executors can be now changed by `seedJobAgentExecutors` property in Custom Resource 

Relates to #158 