### PR TITLE
Fix startup issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ PACKAGES_FOR_UNIT_TESTS = $(shell go list -f '{{.ImportPath}}/' ./... | grep -v 
 E2E_TEST_SELECTOR ?= .*
 
 JENKINS_API_HOSTNAME := $(shell $(JENKINS_API_HOSTNAME_COMMAND))
-OPERATOR_ARGS ?= --jenkins-api-hostname=$(JENKINS_API_HOSTNAME) --jenkins-api-port=$(JENKINS_API_PORT) --jenkins-api-use-nodeport=$(JENKINS_API_USE_NODEPORT) --namespace=$(NAMESPACE) $(OPERATOR_EXTRA_ARGS)
+OPERATOR_ARGS ?= --jenkins-api-hostname=$(JENKINS_API_HOSTNAME) --jenkins-api-port=$(JENKINS_API_PORT) --jenkins-api-use-nodeport=$(JENKINS_API_USE_NODEPORT) $(OPERATOR_EXTRA_ARGS)
 
 .DEFAULT_GOAL := help
 

--- a/pkg/controller/jenkins/jenkins_controller.go
+++ b/pkg/controller/jenkins/jenkins_controller.go
@@ -423,9 +423,16 @@ func (r *ReconcileJenkins) setDefaults(jenkins *v1alpha2.Jenkins, logger logr.Lo
 	if reflect.DeepEqual(jenkins.Spec.Service, v1alpha2.Service{}) {
 		logger.Info("Setting default Jenkins master service")
 		changed = true
-		jenkins.Spec.Service = v1alpha2.Service{
-			Type: corev1.ServiceTypeClusterIP,
-			Port: constants.DefaultHTTPPortInt32,
+		if r.jenkinsAPIConnectionSettings.UseNodePort {
+			jenkins.Spec.Service = v1alpha2.Service{
+				Type: corev1.ServiceTypeNodePort,
+				Port: constants.DefaultHTTPPortInt32,
+			}
+		} else {
+			jenkins.Spec.Service = v1alpha2.Service{
+				Type: corev1.ServiceTypeClusterIP,
+				Port: constants.DefaultHTTPPortInt32,
+			}
 		}
 	}
 	if reflect.DeepEqual(jenkins.Spec.SlaveService, v1alpha2.Service{}) {


### PR DESCRIPTION
This quick bugfix resolves these issues:
* When `make minikube-run` command is executed, the operator informs that `--namespace` argument does not exist
* When `--jenkins-api-use-nodePort` flag is `true` operator creates a `NodePort` type service instead of `ClusterIP` so this flag will work properly