### PR TITLE
Resource quota improvement

### DIFF
--- a/pkg/controller/jenkins/configuration/base/validate.go
+++ b/pkg/controller/jenkins/configuration/base/validate.go
@@ -76,7 +76,7 @@ func (r *ReconcileJenkinsBaseConfiguration) validateResourceQuota() []string {
 
 	var messages []string
 	var minMemoryLimitInMi int64 = 512
-	if memoryLimitInMi < minMemoryLimitInMi {
+	if memoryLimitInMi < minMemoryLimitInMi && memoryLimitInMi != 0 {
 		messages = append(messages,
 			fmt.Sprintf("spec.master.containers[0].resources.limit.memory '%dMi' is too low (must be greater or equal to: '%dMi'",
 				memoryLimitInMi,
@@ -85,7 +85,7 @@ func (r *ReconcileJenkinsBaseConfiguration) validateResourceQuota() []string {
 	}
 
 	var minCPULimitInMillicores int64 = 1000
-	if cpuLimitInMillicores < minCPULimitInMillicores {
+	if cpuLimitInMillicores < minCPULimitInMillicores && cpuLimitInMillicores != 0 {
 		messages = append(messages,
 			fmt.Sprintf("spec.master.containers[0].resources.limit.cpu '%dm' is too low (must be greater or equal to: '%dm'",
 				cpuLimitInMillicores,

--- a/pkg/controller/jenkins/configuration/base/validate_test.go
+++ b/pkg/controller/jenkins/configuration/base/validate_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
@@ -554,6 +555,131 @@ func TestValidateContainerVolumeMounts(t *testing.T) {
 		got := baseReconcileLoop.validateContainerVolumeMounts(jenkins.Spec.Master.Containers[0])
 
 		assert.Equal(t, got, []string{"Not found volume for 'missing-volume' volume mount in container ''"})
+	})
+}
+
+func TestValidateResourceQuota(t *testing.T) {
+	t.Run("happy - not set", func(t *testing.T) {
+		jenkins := v1alpha2.Jenkins{
+			Spec: v1alpha2.JenkinsSpec{
+				Master: v1alpha2.JenkinsMaster{
+					Containers: []v1alpha2.Container{
+						{
+							Resources: v1.ResourceRequirements{},
+						},
+					},
+				},
+			},
+		}
+
+		baseReconcileLoop := New(configuration.Configuration{
+			Jenkins: &jenkins,
+		}, logf.ZapLogger(false), client.JenkinsAPIConnectionSettings{}, nil)
+		got := baseReconcileLoop.validateResourceQuota()
+
+		assert.Nil(t, got)
+	})
+	t.Run("happy - set minimal limits", func(t *testing.T) {
+		jenkins := v1alpha2.Jenkins{
+			Spec: v1alpha2.JenkinsSpec{
+				Master: v1alpha2.JenkinsMaster{
+					Containers: []v1alpha2.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1000m"),
+									v1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		baseReconcileLoop := New(configuration.Configuration{
+			Jenkins: &jenkins,
+		}, logf.ZapLogger(false), client.JenkinsAPIConnectionSettings{}, nil)
+		got := baseReconcileLoop.validateResourceQuota()
+
+		assert.Nil(t, got)
+	})
+	t.Run("too low cpu milliicores", func(t *testing.T) {
+		jenkins := v1alpha2.Jenkins{
+			Spec: v1alpha2.JenkinsSpec{
+				Master: v1alpha2.JenkinsMaster{
+					Containers: []v1alpha2.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("999m"),
+									v1.ResourceMemory: resource.MustParse("512Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		baseReconcileLoop := New(configuration.Configuration{
+			Jenkins: &jenkins,
+		}, logf.ZapLogger(false), client.JenkinsAPIConnectionSettings{}, nil)
+		got := baseReconcileLoop.validateResourceQuota()
+
+		assert.NotNil(t, got)
+	})
+
+	t.Run("too low memory mebibytes", func(t *testing.T) {
+		jenkins := v1alpha2.Jenkins{
+			Spec: v1alpha2.JenkinsSpec{
+				Master: v1alpha2.JenkinsMaster{
+					Containers: []v1alpha2.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("1000m"),
+									v1.ResourceMemory: resource.MustParse("511Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		baseReconcileLoop := New(configuration.Configuration{
+			Jenkins: &jenkins,
+		}, logf.ZapLogger(false), client.JenkinsAPIConnectionSettings{}, nil)
+		got := baseReconcileLoop.validateResourceQuota()
+
+		assert.NotNil(t, got)
+	})
+
+	t.Run("too low memory mebibytes and cpu millicores", func(t *testing.T) {
+		jenkins := v1alpha2.Jenkins{
+			Spec: v1alpha2.JenkinsSpec{
+				Master: v1alpha2.JenkinsMaster{
+					Containers: []v1alpha2.Container{
+						{
+							Resources: v1.ResourceRequirements{
+								Limits: v1.ResourceList{
+									v1.ResourceCPU:    resource.MustParse("999m"),
+									v1.ResourceMemory: resource.MustParse("511Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		baseReconcileLoop := New(configuration.Configuration{
+			Jenkins: &jenkins,
+		}, logf.ZapLogger(false), client.JenkinsAPIConnectionSettings{}, nil)
+		got := baseReconcileLoop.validateResourceQuota()
+
+		assert.NotNil(t, got)
 	})
 }
 

--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -85,7 +84,6 @@ func TestConfiguration(t *testing.T) {
 	createUserConfigurationSecret(t, namespace, stringData)
 	createUserConfigurationConfigMap(t, namespace, numberOfExecutorsEnvName, fmt.Sprintf("${%s}", systemMessageEnvName))
 	jenkins := createJenkinsCR(t, jenkinsCRName, namespace, &[]v1alpha2.SeedJob{mySeedJob.SeedJob}, groovyScripts, casc)
-	createDefaultLimitsForContainersInNamespace(t, namespace)
 	createKubernetesCredentialsProviderSecret(t, namespace, mySeedJob)
 	waitForJenkinsBaseConfigurationToComplete(t, jenkins)
 	verifyJenkinsMasterPodAttributes(t, jenkins)
@@ -177,35 +175,6 @@ unclassified:
 
 	t.Logf("User configuration %+v", *userConfiguration)
 	if err := framework.Global.Client.Create(context.TODO(), userConfiguration, nil); err != nil {
-		t.Fatal(err)
-	}
-}
-
-func createDefaultLimitsForContainersInNamespace(t *testing.T, namespace string) {
-	limitRange := &corev1.LimitRange{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "e2e",
-			Namespace: namespace,
-		},
-		Spec: corev1.LimitRangeSpec{
-			Limits: []corev1.LimitRangeItem{
-				{
-					Type: corev1.LimitTypeContainer,
-					DefaultRequest: map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceCPU:    resource.MustParse("128m"),
-						corev1.ResourceMemory: resource.MustParse("256Mi"),
-					},
-					Default: map[corev1.ResourceName]resource.Quantity{
-						corev1.ResourceCPU:    resource.MustParse("256m"),
-						corev1.ResourceMemory: resource.MustParse("512Mi"),
-					},
-				},
-			},
-		},
-	}
-
-	t.Logf("LimitRange %+v", *limitRange)
-	if err := framework.Global.Client.Create(context.TODO(), limitRange, nil); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
As described in issue https://github.com/jenkinsci/kubernetes-operator/issues/194, this PR features:
- Remove resource limit/request defaults and disable use the enforcement of default values if not set
- If the memory limit set in Custom Resource will be lower than `512MiB` the suitable warning message will be displayed
- If the CPU limit set in Custom Resource will be lower than `1000m` (1000 millicores = 1 CPU) the suitable warning message will be displayed