### PR TITLE
WIP: Add notification when Jenkins is outdated

### DIFF
--- a/pkg/controller/jenkins/client/jenkins.go
+++ b/pkg/controller/jenkins/client/jenkins.go
@@ -30,6 +30,7 @@ type Jenkins interface {
 	CopyJob(copyFrom string, newName string) (*gojenkins.Job, error)
 	DeleteJob(name string) (bool, error)
 	BuildJob(name string, options ...interface{}) (int64, error)
+	GetVersion() string
 	GetNode(name string) (*gojenkins.Node, error)
 	GetLabel(name string) (*gojenkins.Label, error)
 	GetBuild(jobName string, number int64) (*gojenkins.Build, error)
@@ -82,6 +83,11 @@ func (jenkins *jenkins) CreateOrUpdateJob(config, jobName string) (job *gojenkin
 
 	err = job.UpdateConfig(config)
 	return job, false, errors.WithStack(err)
+}
+
+// GetVersion returns current Jenkins version
+func (jenkins *jenkins) GetVersion() string {
+	return jenkins.Version
 }
 
 // BuildJenkinsAPIUrl returns Jenkins API URL

--- a/pkg/controller/jenkins/client/mockgen.go
+++ b/pkg/controller/jenkins/client/mockgen.go
@@ -70,10 +70,23 @@ func (m *MockJenkins) Info() (*gojenkins.ExecutorResponse, error) {
 	return ret0, ret1
 }
 
+// GetVersion mocks base method
+func (m *MockJenkins) GetVersion() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVersion")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
 // Info indicates an expected call of Info
 func (mr *MockJenkinsMockRecorder) Info() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Info", reflect.TypeOf((*MockJenkins)(nil).Info))
+}
+
+func (mr *MockJenkinsMockRecorder) GetVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockJenkins)(nil).Info))
 }
 
 // SafeRestart mocks base method


### PR DESCRIPTION
* [x] Check latest *Jenkins* version by `GET` request to `https://updates.jenkins.io/current/latestCore.txt`
* [x] Compare Jenkins current version and latest version and check if the *Jenkins* is outdated
* [ ] If Jenkins is outdated - notify user using the `notification` feature
