### PR TITLE
Add Bitbucket trigger for seed job

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,11 +20,11 @@ require (
 	github.com/spf13/pflag v1.0.3
 	github.com/stretchr/testify v1.3.0
 	go.uber.org/zap v1.9.1
-	golang.org/x/crypto v0.0.0-20190909091759-094676da4a83 // indirect
+	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/net v0.0.0-20190909003024-a7b16738d86b
 	golang.org/x/sys v0.0.0-20190910064555-bbd175535a8b // indirect
 	golang.org/x/text v0.3.2 // indirect
-	golang.org/x/tools v0.0.0-20191004055002-72853e10c5a3 // indirect
+	golang.org/x/tools v0.0.0-20200205141839-4abfd4a1628e // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	k8s.io/api v0.0.0-20190612125737-db0771252981

--- a/go.sum
+++ b/go.sum
@@ -419,6 +419,8 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190404164418-38d8ce5564a5/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
 golang.org/x/crypto v0.0.0-20190909091759-094676da4a83 h1:mgAKeshyNqWKdENOnQsg+8dRTwZFIwFaO3HNl52sweA=
 golang.org/x/crypto v0.0.0-20190909091759-094676da4a83/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550 h1:ObdrDkeb4kJdCP557AjRjq69pTHfNouLtWZG7j9rPN8=
+golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/lint v0.0.0-20180702182130-06c8688daad7/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
@@ -426,6 +428,9 @@ golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1/go.mod h1:UVdnD1Gm6xHRNCYTk
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f h1:hX65Cu3JDlGH3uEdK7I99Ii+9kjD6mvnnpfLdEAH0x4=
 golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+golang.org/x/lint v0.0.0-20200130185559-910be7a94367 h1:0IiAsCRByjO2QjX7ZPkw5oU9x+n1YqRL802rjC0c3Aw=
+golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
+golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -507,7 +512,11 @@ golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190408170212-12dd9f86f350/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20191004055002-72853e10c5a3 h1:2AmBLzhAfXj+2HCW09VCkJtHIYgHTIPcTeYqgP7Bwt0=
 golang.org/x/tools v0.0.0-20191004055002-72853e10c5a3/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
+golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
+golang.org/x/tools v0.0.0-20200205141839-4abfd4a1628e h1:JdEzLb04S2BEPrWqUDsgo7JXSq8pQlzIHbrBQN5o7TY=
+golang.org/x/tools v0.0.0-20200205141839-4abfd4a1628e/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.0.0-20180910000450-7ca32eb868bf/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181030000543-1d582fd0359e/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=
 google.golang.org/api v0.0.0-20181220000619-583d854617af/go.mod h1:4mhQ8q/RsB7i+udVvVy5NUi08OU8ZlA0gRVgrF7VFY0=

--- a/pkg/apis/jenkins/v1alpha2/jenkins_types.go
+++ b/pkg/apis/jenkins/v1alpha2/jenkins_types.go
@@ -552,6 +552,10 @@ type SeedJob struct {
 	// +optional
 	JenkinsCredentialType JenkinsCredentialType `json:"credentialType,omitempty"`
 
+	// BitbucketPushTrigger is used for Bitbucket web hooks
+	// +optional
+	BitbucketPushTrigger bool `json:"bitbucketPushTrigger"`
+
 	// GitHubPushTrigger is used for GitHub web hooks
 	// +optional
 	GitHubPushTrigger bool `json:"githubPushTrigger"`

--- a/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs.go
+++ b/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs.go
@@ -70,6 +70,9 @@ import org.jenkinsci.plugins.workflow.cps.CpsScmFlowDefinition;
 {{ if .GitHubPushTrigger }}
 import com.cloudbees.jenkins.GitHubPushTrigger;
 {{ end }}
+{{ if .BitbucketPushTrigger }}
+import com.cloudbees.jenkins.plugins.BitBucketTrigger;
+{{ end }}
 import hudson.model.FreeStyleProject;
 import hudson.model.labels.LabelAtom;
 import hudson.plugins.git.BranchSpec;
@@ -126,6 +129,10 @@ jobRef.addTrigger(new SCMTrigger("{{ .PollSCM }}"))
 
 {{ if .GitHubPushTrigger }}
 jobRef.addTrigger(new GitHubPushTrigger())
+{{ end }}
+
+{{ if .BitbucketPushTrigger }}
+jobRef.addTrigger(new BitBucketTrigger())
 {{ end }}
 
 {{ if .BuildPeriodically }}
@@ -470,6 +477,7 @@ func seedJobCreatingGroovyScript(seedJob v1alpha2.SeedJob) (string, error) {
 		Targets               string
 		RepositoryBranch      string
 		RepositoryURL         string
+		BitbucketPushTrigger  bool
 		GitHubPushTrigger     bool
 		BuildPeriodically     string
 		PollSCM               string
@@ -485,6 +493,7 @@ func seedJobCreatingGroovyScript(seedJob v1alpha2.SeedJob) (string, error) {
 		Targets:               seedJob.Targets,
 		RepositoryBranch:      seedJob.RepositoryBranch,
 		RepositoryURL:         seedJob.RepositoryURL,
+		BitbucketPushTrigger:  seedJob.BitbucketPushTrigger,
 		GitHubPushTrigger:     seedJob.GitHubPushTrigger,
 		BuildPeriodically:     seedJob.BuildPeriodically,
 		PollSCM:               seedJob.PollSCM,


### PR DESCRIPTION
This PR adds the ability to enable a Bitbucket push trigger for the seed job. It follows the same patterns that were established for the GitHub trigger.

I am not sure what the versioning criteria is, so I left it as 0.3.3 for now.