### PR TITLE
Update Role to allow calling Openshift API

### DIFF
--- a/pkg/controller/jenkins/configuration/base/resources/rbac.go
+++ b/pkg/controller/jenkins/configuration/base/resources/rbac.go
@@ -26,28 +26,18 @@ func NewRole(meta metav1.ObjectMeta) *v1.Role {
 		Rules: []v1.PolicyRule{
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods/portforward"},
-				Verbs:     []string{createVerb},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods"},
+				Resources: []string{"pods", "pods/exec", "pods/portforward", "pods/log"},
 				Verbs:     []string{createVerb, deleteVerb, getVerb, listVerb, patchVerb, updateVerb, watchVerb},
 			},
 			{
 				APIGroups: []string{""},
-				Resources: []string{"pods/exec"},
+				Resources: []string{"secrets", "configmaps"},
 				Verbs:     []string{createVerb, deleteVerb, getVerb, listVerb, patchVerb, updateVerb, watchVerb},
 			},
 			{
-				APIGroups: []string{""},
-				Resources: []string{"pods/log"},
-				Verbs:     []string{getVerb, listVerb, watchVerb},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"secrets"},
-				Verbs:     []string{getVerb, listVerb, watchVerb},
+				APIGroups: []string{"build.openshift.io", "image.openshift.io"},
+				Resources: []string{"*"},
+				Verbs:     []string{createVerb, deleteVerb, getVerb, listVerb, patchVerb, updateVerb, watchVerb},
 			},
 		},
 	}


### PR DESCRIPTION
```
2020-02-19 22:16:25.336+0000 [id=26]    SEVERE  i.f.j.o.ImageStreamWatcher$1#doRun: Failed to load ImageStreams: io.fabric8.kubernetes.client.KubernetesClientException: Failure exe
cuting: GET at: https://kubernetes.default/apis/image.openshift.io/v1/namespaces/jenkins-operator/imagestreams. Message: Forbidden!Configured service account doesn't have access. S
ervice account may have been revoked. imagestreams.image.openshift.io is forbidden: User "system:serviceaccount:jenkins-operator:jenkins-operator-jenkin-with-op" cannot list resour
ce "imagestreams" in API group "image.openshift.io" in the namespace "jenkins-operator":
```
- Put `pods` related Policies in the same Rule
- Add ConfigMaps along with Secrets which Jenkins plugins should have privileges to `edit`
- Add Policy to allow accessing BuildConfig and ImageStream Openshift API 
