### PR TITLE
define resource limits and requests for seedjob agent

### DIFF
--- a/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs.go
+++ b/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs.go
@@ -22,6 +22,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs.go
+++ b/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs.go
@@ -438,6 +438,16 @@ func agentDeployment(jenkins *v1alpha2.Jenkins, namespace string, agentName stri
 									MountPath: workspaceVolumePath,
 								},
 							},
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("0.1"),
+									corev1.ResourceMemory: resource.MustParse("256Mi"),
+								},
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("0.05"),
+									corev1.ResourceMemory: resource.MustParse("128Mi"),
+								},
+							},
 						},
 					},
 					Volumes: []corev1.Volume{


### PR DESCRIPTION
Hello, I experienced a similar issue with #228. I think this would solve the problem. While creating the seed job agent we can specify resource limits and requests.

I set the thresholds after observing jenkins-operator deployments in multiple clusters for couple of days. If you have concerns we can adjust them.