### PR TITLE
Fix documentation regarding notifications

### DIFF
--- a/docs/docs/getting-started/latest/notifications/index.html
+++ b/docs/docs/getting-started/latest/notifications/index.html
@@ -673,7 +673,7 @@
 spec:
   master:
     notifications:
-    - loggingLevel: info
+    - level: info
       verbose: true
       name: &lt;name&gt;
       slack:
@@ -693,7 +693,7 @@ spec:
 spec:
   master:
     notifications:
-    - loggingLevel: info
+    - level: info
       verbose: true
       name: &lt;name&gt;
       teams:
@@ -711,7 +711,7 @@ spec:
 spec:
   master:
     notifications:
-    - loggingLevel: info
+    - level: info
       verbose: true
       name: &lt;name&gt;
       mailgun:
@@ -729,7 +729,7 @@ spec:
 <p>As you see there is two debugging options:</p>
 
 <ul>
-<li><p><code>loggingLevel</code> (warning/info) - Set level of messages to send.</p></li>
+<li><p><code>level</code> (warning/info) - Set level of messages to send.</p></li>
 
 <li><p><code>verbose</code> - Print stacktrace and additional error messages</p></li>
 </ul>
@@ -743,7 +743,7 @@ For example you will send notifications to Slack and Teams.</p>
 spec:
   master:
     notifications:
-    - loggingLevel: info
+    - level: info
       verbose: true
       name: nslack
       slack:
@@ -751,7 +751,7 @@ spec:
           secret:
             name: &lt;secret_name&gt;
           key: &lt;key&gt;
-    - loggingLevel: info
+    - level: info
       verbose: true
       name: nteams
       teams:

--- a/website/content/en/docs/Getting Started/latest/notifications.md
+++ b/website/content/en/docs/Getting Started/latest/notifications.md
@@ -24,7 +24,7 @@ kind: Jenkins
 spec:
   master:
     notifications:
-    - loggingLevel: info
+    - level: info
       verbose: true
       name: <name>
       slack:
@@ -45,7 +45,7 @@ kind: Jenkins
 spec:
   master:
     notifications:
-    - loggingLevel: info
+    - level: info
       verbose: true
       name: <name>
       teams:
@@ -64,7 +64,7 @@ kind: Jenkins
 spec:
   master:
     notifications:
-    - loggingLevel: info
+    - level: info
       verbose: true
       name: <name>
       mailgun:
@@ -81,7 +81,7 @@ spec:
 
 As you see there is two debugging options: 
 
-* `loggingLevel` (warning/info) - Set level of messages to send.
+* `level` (warning/info) - Set level of messages to send.
 
 * `verbose` - Print stacktrace and additional error messages
 
@@ -95,7 +95,7 @@ kind: Jenkins
 spec:
   master:
     notifications:
-    - loggingLevel: info
+    - level: info
       verbose: true
       name: nslack
       slack:
@@ -103,7 +103,7 @@ spec:
           secret:
             name: <secret_name>
           key: <key>
-    - loggingLevel: info
+    - level: info
       verbose: true
       name: nteams
       teams:


### PR DESCRIPTION
# Changes

Fix documentation regarding notifications.

In the documentation examples field is called `loggingLevel`, which is not aligned with [schema](https://github.com/jenkinsci/kubernetes-operator/blob/master/pkg/apis/jenkins/v1alpha2/jenkins_types.go#L108) where the field is called `level`. Fix inconsistency by updating the documentation.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).