### PR TITLE
Must call r.Client.Status().Update to update the status field of CRD

### DIFF
--- a/pkg/controller/jenkins/configuration/base/pod.go
+++ b/pkg/controller/jenkins/configuration/base/pod.go
@@ -140,8 +140,6 @@ func (r *ReconcileJenkinsBaseConfiguration) checkForPodRecreation(currentJenkins
 	return reason.NewPodRestart(reason.OperatorSource, messages, verbose...)
 }
 
-
-
 func (r *ReconcileJenkinsBaseConfiguration) ensureJenkinsMasterPod(meta metav1.ObjectMeta) (reconcile.Result, error) {
 	userAndPasswordHash, err := r.calculateUserAndPasswordHash()
 	if err != nil {
@@ -179,7 +177,7 @@ func (r *ReconcileJenkinsBaseConfiguration) ensureJenkinsMasterPod(meta metav1.O
 			PendingBackup:       r.Configuration.Jenkins.Status.LastBackup,
 			UserAndPasswordHash: userAndPasswordHash,
 		}
-		return reconcile.Result{Requeue: true}, r.Client.Update(context.TODO(), r.Configuration.Jenkins)
+		return reconcile.Result{Requeue: true}, r.Client.Status().Update(context.TODO(), r.Configuration.Jenkins)
 	} else if err != nil && !apierrors.IsNotFound(err) {
 		return reconcile.Result{}, stackerr.WithStack(err)
 	}
@@ -222,4 +220,3 @@ func (r *ReconcileJenkinsBaseConfiguration) ensureJenkinsMasterPod(meta metav1.O
 
 	return reconcile.Result{}, nil
 }
-


### PR DESCRIPTION
r.Client.Status().update is the correct way to update the status field of Jenkins, otherwise the operator will continuous terminating and creating the Jenkins master and will never succeed because of the code from line 103 - line 110 in https://github.com/jenkinsci/kubernetes-operator/blob/master/pkg/controller/jenkins/configuration/base/pod.go 