### PR TITLE
Default rule policy now allows watching resources required by OpenShift

### DIFF
--- a/deploy/crds/openshift_jenkins_v1alpha2_jenkins_cr.yaml
+++ b/deploy/crds/openshift_jenkins_v1alpha2_jenkins_cr.yaml
@@ -1,16 +1,70 @@
 apiVersion: jenkins.io/v1alpha2
 kind: Jenkins
 metadata:
+  annotations:
+    jenkins.io/openshift-mode: 'true'
   name: jenkins
 spec:
   master:
     containers:
-    - name: jenkins-master
-      image: quay.io/openshift/origin-jenkins:latest
-      resources:
-        limits:
-          cpu: 1500m
-          memory: 3Gi
-        requests:
-          cpu: "1"
-          memory: 500Mi
+      - name: jenkins-master
+        command:
+          - /usr/bin/go-init
+          - '-main'
+          - /usr/libexec/s2i/run
+        env:
+          - name: OPENSHIFT_ENABLE_OAUTH
+            value: 'true'
+          - name: OPENSHIFT_ENABLE_REDIRECT_PROMPT
+            value: 'true'
+          - name: DISABLE_ADMINISTRATIVE_MONITORS
+            value: 'false'
+          - name: KUBERNETES_MASTER
+            value: 'https://kubernetes.default:443'
+          - name: KUBERNETES_TRUST_CERTIFICATES
+            value: 'true'
+          - name: JENKINS_SERVICE_NAME
+            value: jenkins-operator-http-example
+          - name: JNLP_SERVICE_NAME
+            value: jenkins-operator-slave-example
+          - name: JENKINS_UC_INSECURE
+            value: 'false'
+          - name: JENKINS_HOME
+            value: /var/lib/jenkins
+          - name: JAVA_OPTS
+            value: >-
+              -XX:+UnlockExperimentalVMOptions -XX:+UnlockExperimentalVMOptions
+              -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1
+              -Djenkins.install.runSetupWizard=false -Djava.awt.headless=true
+        image: 'quay.io/openshift/origin-jenkins:latest'
+        imagePullPolicy: Always
+        livenessProbe:
+          httpGet:
+            path: /login
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 420
+          periodSeconds: 360
+          timeoutSeconds: 240
+        readinessProbe:
+          httpGet:
+            path: /login
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 3
+          periodSeconds: 0
+          timeoutSeconds: 240
+        resources:
+          limits:
+            cpu: 600m
+            memory: 4Gi
+          requests:
+            cpu: 500m
+            memory: 3Gi
+  service:
+    port: 8080
+    type: ClusterIP
+  slaveService:
+    port: 50000
+    type: ClusterIP
+

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -88,3 +88,20 @@ rules:
       - get
       - list
       - watch
+  - apiGroups:
+      - "image.openshift.io"
+    resources:
+      - imagestreams
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "build.openshift.io"
+    resources:
+      - builds
+      - buildconfigs
+    verbs:
+      - get
+      - list
+      - watch

--- a/pkg/controller/jenkins/configuration/base/resources/rbac.go
+++ b/pkg/controller/jenkins/configuration/base/resources/rbac.go
@@ -6,50 +6,29 @@ import (
 )
 
 const (
-	createVerb = "create"
-	deleteVerb = "delete"
-	getVerb    = "get"
-	listVerb   = "list"
-	watchVerb  = "watch"
-	patchVerb  = "patch"
-	updateVerb = "update"
+	createVerb        = "create"
+	deleteVerb        = "delete"
+	getVerb           = "get"
+	listVerb          = "list"
+	watchVerb         = "watch"
+	patchVerb         = "patch"
+	updateVerb        = "update"
+	EmptyApiGroups    = ""
+	OpenshiftApiGroup = "image.openshift.io"
+	BuildApiGroup     = "build.openshift.io"
+
 )
 
 // NewRole returns rbac role for jenkins master
 func NewRole(meta metav1.ObjectMeta) *v1.Role {
+	rules := NewDefaultPolicyRules()
 	return &v1.Role{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Role",
 			APIVersion: "rbac.authorization.k8s.io/v1",
 		},
 		ObjectMeta: meta,
-		Rules: []v1.PolicyRule{
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods/portforward"},
-				Verbs:     []string{createVerb},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods"},
-				Verbs:     []string{createVerb, deleteVerb, getVerb, listVerb, patchVerb, updateVerb, watchVerb},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods/exec"},
-				Verbs:     []string{createVerb, deleteVerb, getVerb, listVerb, patchVerb, updateVerb, watchVerb},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"pods/log"},
-				Verbs:     []string{getVerb, listVerb, watchVerb},
-			},
-			{
-				APIGroups: []string{""},
-				Resources: []string{"secrets"},
-				Verbs:     []string{getVerb, listVerb, watchVerb},
-			},
-		},
+		Rules:      rules,
 	}
 }
 
@@ -73,4 +52,31 @@ func NewRoleBinding(name, namespace, serviceAccountName string, roleRef v1.RoleR
 			},
 		},
 	}
+}
+
+func NewDefaultPolicyRules() []v1.PolicyRule {
+	var rules []v1.PolicyRule
+	Default := []string{createVerb, deleteVerb, getVerb, listVerb, patchVerb, updateVerb, watchVerb}
+	ReadOnly := []string{getVerb, listVerb, watchVerb}
+
+	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "configmaps", Default))
+	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "pods", Default))
+	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "pods/exec", Default))
+	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "pods/portforward", Default))
+	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "pods/log", ReadOnly))
+	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "secrets", ReadOnly))
+	rules = append(rules,  NewPolicyRule(OpenshiftApiGroup, "imagestreams", ReadOnly))
+	rules = append(rules,  NewPolicyRule(BuildApiGroup, "buildconfigs", ReadOnly))
+	rules = append(rules,  NewPolicyRule(BuildApiGroup, "builds", ReadOnly))
+	return rules
+}
+
+// NewPolicyRule returns a policyRule allowing verbs on resources
+func NewPolicyRule(apiGroup string, resource string, verbs []string) v1.PolicyRule {
+	rule := v1.PolicyRule{
+		APIGroups: []string{apiGroup},
+		Resources: []string{resource},
+		Verbs:     verbs,
+	}
+	return rule
 }

--- a/pkg/controller/jenkins/configuration/base/resources/rbac.go
+++ b/pkg/controller/jenkins/configuration/base/resources/rbac.go
@@ -56,18 +56,21 @@ func NewRoleBinding(name, namespace, serviceAccountName string, roleRef v1.RoleR
 
 func NewDefaultPolicyRules() []v1.PolicyRule {
 	var rules []v1.PolicyRule
-	Default := []string{createVerb, deleteVerb, getVerb, listVerb, patchVerb, updateVerb, watchVerb}
 	ReadOnly := []string{getVerb, listVerb, watchVerb}
+	Default  := []string{createVerb, deleteVerb, getVerb, listVerb, patchVerb, updateVerb, watchVerb}
+	Create   := []string{createVerb}
 
-	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "configmaps", Default))
+	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "pods/portforward", Create))
 	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "pods", Default))
 	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "pods/exec", Default))
-	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "pods/portforward", Default))
+	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "configmaps", ReadOnly))
 	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "pods/log", ReadOnly))
 	rules = append(rules,  NewPolicyRule(EmptyApiGroups, "secrets", ReadOnly))
-	rules = append(rules,  NewPolicyRule(OpenshiftApiGroup, "imagestreams", ReadOnly))
-	rules = append(rules,  NewPolicyRule(BuildApiGroup, "buildconfigs", ReadOnly))
-	rules = append(rules,  NewPolicyRule(BuildApiGroup, "builds", ReadOnly))
+
+	rules = append(rules,  NewOpenShiftPolicyRule(OpenshiftApiGroup, "imagestreams", ReadOnly))
+	rules = append(rules,  NewOpenShiftPolicyRule(BuildApiGroup, "buildconfigs", ReadOnly))
+	rules = append(rules,  NewOpenShiftPolicyRule(BuildApiGroup, "builds", ReadOnly))
+
 	return rules
 }
 
@@ -80,3 +83,9 @@ func NewPolicyRule(apiGroup string, resource string, verbs []string) v1.PolicyRu
 	}
 	return rule
 }
+
+// NewPolicyRule returns a policyRule allowing verbs on resources
+func NewOpenShiftPolicyRule(apiGroup string, resource string, verbs []string) v1.PolicyRule {
+	return NewPolicyRule(apiGroup,resource,verbs)
+}
+


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Changes the default RulePolicies for the jenkins-operator-${jenkins.spec.name} role.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes
```
Role jenkins-operator-jenkins now has default permissions required by OpenShift
```
