### PR TITLE
Makefile complains about minikube not found when running inside docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ PACKAGES_FOR_UNIT_TESTS = $(shell go list -f '{{.ImportPath}}/' ./... | grep -v 
 # Run all the e2e tests by default
 E2E_TEST_SELECTOR ?= .*
 
-JENKINS_API_HOSTNAME := $(shell $(JENKINS_API_HOSTNAME_COMMAND) 2> /dev/null || echo 127.0.0.1 )
+JENKINS_API_HOSTNAME := $(shell $(JENKINS_API_HOSTNAME_COMMAND) 2> /dev/null || echo "" )
 OPERATOR_ARGS ?= --jenkins-api-hostname=$(JENKINS_API_HOSTNAME) --jenkins-api-port=$(JENKINS_API_PORT) --jenkins-api-use-nodeport=$(JENKINS_API_USE_NODEPORT) $(OPERATOR_EXTRA_ARGS)
 
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -65,7 +65,7 @@ PACKAGES_FOR_UNIT_TESTS = $(shell go list -f '{{.ImportPath}}/' ./... | grep -v 
 # Run all the e2e tests by default
 E2E_TEST_SELECTOR ?= .*
 
-JENKINS_API_HOSTNAME := $(shell $(JENKINS_API_HOSTNAME_COMMAND))
+JENKINS_API_HOSTNAME := $(shell $(JENKINS_API_HOSTNAME_COMMAND) 2> /dev/null || echo 127.0.0.1 )
 OPERATOR_ARGS ?= --jenkins-api-hostname=$(JENKINS_API_HOSTNAME) --jenkins-api-port=$(JENKINS_API_PORT) --jenkins-api-use-nodeport=$(JENKINS_API_USE_NODEPORT) $(OPERATOR_EXTRA_ARGS)
 
 .DEFAULT_GOAL := help


### PR DESCRIPTION
# Changes
when the tests run into a docker container, the makefile tries to get the jenkins command from the docker container using minikube ip command which is complaining.
Instead, if minikube is not found, it will use 127.0.0.1 ip address.