### PR TITLE
Update deprecated agent to supported image used in SeedJobs Agents

### DIFF
--- a/cicd/pipelines/build.jenkins
+++ b/cicd/pipelines/build.jenkins
@@ -7,7 +7,7 @@ def workdir = "${workspace}/src/github.com/jenkinsci/kubernetes-operator/"
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:alpine'),
+                containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:alpine'),
                 containerTemplate(name: 'go', image: 'golang:1-alpine', command: 'cat', ttyEnabled: true),
         ],
         envVars: [

--- a/docs/docs/getting-started/latest/configuration/index.html
+++ b/docs/docs/getting-started/latest/configuration/index.html
@@ -731,7 +731,7 @@ def workdir = &quot;${workspace}/src/github.com/jenkinsci/kubernetes-operator/&q
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:alpine'),
+                containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:alpine'),
                 containerTemplate(name: 'go', image: 'golang:1-alpine', command: 'cat', ttyEnabled: true),
         ],
         envVars: [

--- a/docs/docs/getting-started/latest/index.xml
+++ b/docs/docs/getting-started/latest/index.xml
@@ -153,7 +153,7 @@ def workdir = &amp;quot;${workspace}/src/github.com/jenkinsci/kubernetes-operato
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/jnlp-slave:alpine&#39;),
+                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/inbound-agent:alpine&#39;),
                 containerTemplate(name: &#39;go&#39;, image: &#39;golang:1-alpine&#39;, command: &#39;cat&#39;, ttyEnabled: true),
         ],
         envVars: [

--- a/docs/docs/getting-started/v0.1.x/configuration/index.html
+++ b/docs/docs/getting-started/v0.1.x/configuration/index.html
@@ -725,7 +725,7 @@ def workdir = &quot;${workspace}/src/github.com/jenkinsci/kubernetes-operator/&q
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:alpine'),
+                containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:alpine'),
                 containerTemplate(name: 'go', image: 'golang:1-alpine', command: 'cat', ttyEnabled: true),
         ],
         envVars: [

--- a/docs/docs/getting-started/v0.1.x/index.xml
+++ b/docs/docs/getting-started/v0.1.x/index.xml
@@ -154,7 +154,7 @@ def workdir = &amp;quot;${workspace}/src/github.com/jenkinsci/kubernetes-operato
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/jnlp-slave:alpine&#39;),
+                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/inbound-agent:alpine&#39;),
                 containerTemplate(name: &#39;go&#39;, image: &#39;golang:1-alpine&#39;, command: &#39;cat&#39;, ttyEnabled: true),
         ],
         envVars: [

--- a/docs/docs/getting-started/v0.2.x/configuration/index.html
+++ b/docs/docs/getting-started/v0.2.x/configuration/index.html
@@ -730,7 +730,7 @@ def workdir = &quot;${workspace}/src/github.com/jenkinsci/kubernetes-operator/&q
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:alpine'),
+                containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:alpine'),
                 containerTemplate(name: 'go', image: 'golang:1-alpine', command: 'cat', ttyEnabled: true),
         ],
         envVars: [

--- a/docs/docs/getting-started/v0.2.x/index.xml
+++ b/docs/docs/getting-started/v0.2.x/index.xml
@@ -152,7 +152,7 @@ def workdir = &amp;quot;${workspace}/src/github.com/jenkinsci/kubernetes-operato
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/jnlp-slave:alpine&#39;),
+                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/inbound-agent:alpine&#39;),
                 containerTemplate(name: &#39;go&#39;, image: &#39;golang:1-alpine&#39;, command: &#39;cat&#39;, ttyEnabled: true),
         ],
         envVars: [

--- a/docs/docs/getting-started/v0.3.x/configuration/index.html
+++ b/docs/docs/getting-started/v0.3.x/configuration/index.html
@@ -730,7 +730,7 @@ def workdir = &quot;${workspace}/src/github.com/jenkinsci/kubernetes-operator/&q
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:alpine'),
+                containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:alpine'),
                 containerTemplate(name: 'go', image: 'golang:1-alpine', command: 'cat', ttyEnabled: true),
         ],
         envVars: [

--- a/docs/docs/getting-started/v0.3.x/index.xml
+++ b/docs/docs/getting-started/v0.3.x/index.xml
@@ -153,7 +153,7 @@ def workdir = &amp;quot;${workspace}/src/github.com/jenkinsci/kubernetes-operato
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/jnlp-slave:alpine&#39;),
+                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/inbound-agent:alpine&#39;),
                 containerTemplate(name: &#39;go&#39;, image: &#39;golang:1-alpine&#39;, command: &#39;cat&#39;, ttyEnabled: true),
         ],
         envVars: [

--- a/docs/docs/index.xml
+++ b/docs/docs/index.xml
@@ -420,7 +420,7 @@ def workdir = &amp;quot;${workspace}/src/github.com/jenkinsci/kubernetes-operato
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/jnlp-slave:alpine&#39;),
+                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/inbound-agent:alpine&#39;),
                 containerTemplate(name: &#39;go&#39;, image: &#39;golang:1-alpine&#39;, command: &#39;cat&#39;, ttyEnabled: true),
         ],
         envVars: [
@@ -726,7 +726,7 @@ def workdir = &amp;quot;${workspace}/src/github.com/jenkinsci/kubernetes-operato
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/jnlp-slave:alpine&#39;),
+                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/inbound-agent:alpine&#39;),
                 containerTemplate(name: &#39;go&#39;, image: &#39;golang:1-alpine&#39;, command: &#39;cat&#39;, ttyEnabled: true),
         ],
         envVars: [
@@ -1026,7 +1026,7 @@ def workdir = &amp;quot;${workspace}/src/github.com/jenkinsci/kubernetes-operato
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/jnlp-slave:alpine&#39;),
+                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/inbound-agent:alpine&#39;),
                 containerTemplate(name: &#39;go&#39;, image: &#39;golang:1-alpine&#39;, command: &#39;cat&#39;, ttyEnabled: true),
         ],
         envVars: [
@@ -1289,7 +1289,7 @@ def workdir = &amp;quot;${workspace}/src/github.com/jenkinsci/kubernetes-operato
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/jnlp-slave:alpine&#39;),
+                containerTemplate(name: &#39;jnlp&#39;, image: &#39;jenkins/inbound-agent:alpine&#39;),
                 containerTemplate(name: &#39;go&#39;, image: &#39;golang:1-alpine&#39;, command: &#39;cat&#39;, ttyEnabled: true),
         ],
         envVars: [

--- a/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs.go
+++ b/pkg/controller/jenkins/configuration/user/seedjobs/seedjobs.go
@@ -409,7 +409,7 @@ func agentDeployment(jenkins *v1alpha2.Jenkins, namespace string, agentName stri
 					Containers: []corev1.Container{
 						{
 							Name:  "jnlp",
-							Image: "jenkins/jnlp-slave:alpine",
+							Image: "jenkins/inbound-agent:alpine",
 							Env: []corev1.EnvVar{
 								{
 									Name: "JENKINS_TUNNEL",

--- a/website/content/en/docs/Getting Started/latest/configuration.md
+++ b/website/content/en/docs/Getting Started/latest/configuration.md
@@ -61,7 +61,7 @@ def workdir = "${workspace}/src/github.com/jenkinsci/kubernetes-operator/"
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:alpine'),
+                containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:alpine'),
                 containerTemplate(name: 'go', image: 'golang:1-alpine', command: 'cat', ttyEnabled: true),
         ],
         envVars: [

--- a/website/content/en/docs/Getting Started/v0.1.x/configuration.md
+++ b/website/content/en/docs/Getting Started/v0.1.x/configuration.md
@@ -59,7 +59,7 @@ def workdir = "${workspace}/src/github.com/jenkinsci/kubernetes-operator/"
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:alpine'),
+                containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:alpine'),
                 containerTemplate(name: 'go', image: 'golang:1-alpine', command: 'cat', ttyEnabled: true),
         ],
         envVars: [

--- a/website/content/en/docs/Getting Started/v0.2.x/configuration.md
+++ b/website/content/en/docs/Getting Started/v0.2.x/configuration.md
@@ -61,7 +61,7 @@ def workdir = "${workspace}/src/github.com/jenkinsci/kubernetes-operator/"
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:alpine'),
+                containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:alpine'),
                 containerTemplate(name: 'go', image: 'golang:1-alpine', command: 'cat', ttyEnabled: true),
         ],
         envVars: [

--- a/website/content/en/docs/Getting Started/v0.3.x/configuration.md
+++ b/website/content/en/docs/Getting Started/v0.3.x/configuration.md
@@ -61,7 +61,7 @@ def workdir = "${workspace}/src/github.com/jenkinsci/kubernetes-operator/"
 
 podTemplate(label: label,
         containers: [
-                containerTemplate(name: 'jnlp', image: 'jenkins/jnlp-slave:alpine'),
+                containerTemplate(name: 'jnlp', image: 'jenkins/inbound-agent:alpine'),
                 containerTemplate(name: 'go', image: 'golang:1-alpine', command: 'cat', ttyEnabled: true),
         ],
         envVars: [


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`jenkins/jnlp-slave:alpine` used as the iamge for seedjobs agents is now deprecated as gven in https://hub.docker.com/r/jenkins/inbound-agent/ and is replaced here with `jenkins/inbound-agent:alpine`

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._

## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
