### PR TITLE
Use Deployment instead of Pod (intermediate PR)

### DIFF
--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -3,6 +3,7 @@ package apis
 import (
 	"github.com/jenkinsci/kubernetes-operator/pkg/apis/jenkins/v1alpha2"
 	routev1 "github.com/openshift/api/route/v1"
+	appsv1 "k8s.io/api/apps/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
 )
@@ -19,4 +20,5 @@ func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
 	AddToSchemes = append(AddToSchemes, v1alpha2.SchemeBuilder.AddToScheme)
 	AddToSchemes = append(AddToSchemes, routev1.AddToScheme)
+	AddToSchemes = append(AddToSchemes, appsv1.AddToScheme)
 }

--- a/pkg/controller/jenkins/configuration/backuprestore/backuprestore.go
+++ b/pkg/controller/jenkins/configuration/backuprestore/backuprestore.go
@@ -137,7 +137,7 @@ func (bar *BackupAndRestore) Restore(jenkinsClient jenkinsclient.Jenkins) error 
 		backupNumber = jenkins.Status.LastBackup
 	}
 	bar.logger.Info(fmt.Sprintf("Restoring backup '%d'", backupNumber))
-	podName := resources.GetJenkinsMasterPodName(*jenkins)
+	podName := resources.GetJenkinsMasterPodName(jenkins)
 	command := jenkins.Spec.Restore.Action.Exec.Command
 	command = append(command, fmt.Sprintf("%d", backupNumber))
 	_, _, err := bar.Exec(podName, jenkins.Spec.Restore.ContainerName, command)
@@ -170,7 +170,7 @@ func (bar *BackupAndRestore) Backup(setBackupDoneBeforePodDeletion bool) error {
 	}
 	backupNumber := jenkins.Status.PendingBackup
 	bar.logger.Info(fmt.Sprintf("Performing backup '%d'", backupNumber))
-	podName := resources.GetJenkinsMasterPodName(*jenkins)
+	podName := resources.GetJenkinsMasterPodName(jenkins)
 	command := jenkins.Spec.Backup.Action.Exec.Command
 	command = append(command, fmt.Sprintf("%d", backupNumber))
 	_, _, err := bar.Exec(podName, jenkins.Spec.Backup.ContainerName, command)

--- a/pkg/controller/jenkins/configuration/base/deployment.go
+++ b/pkg/controller/jenkins/configuration/base/deployment.go
@@ -1,0 +1,55 @@
+package base
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jenkinsci/kubernetes-operator/pkg/apis/jenkins/v1alpha2"
+	"github.com/jenkinsci/kubernetes-operator/pkg/controller/jenkins/configuration/base/resources"
+	"github.com/jenkinsci/kubernetes-operator/pkg/controller/jenkins/notifications/event"
+	"github.com/jenkinsci/kubernetes-operator/pkg/controller/jenkins/notifications/reason"
+	"github.com/jenkinsci/kubernetes-operator/version"
+
+	stackerr "github.com/pkg/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func (r *ReconcileJenkinsBaseConfiguration) ensureJenkinsDeployment(meta metav1.ObjectMeta) (reconcile.Result, error) {
+	userAndPasswordHash, err := r.calculateUserAndPasswordHash()
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	_, err = r.GetJenkinsDeployment()
+	if apierrors.IsNotFound(err) {
+		jenkinsDeployment := resources.NewJenkinsDeployment(meta, r.Configuration.Jenkins)
+		*r.Notifications <- event.Event{
+			Jenkins: *r.Configuration.Jenkins,
+			Phase:   event.PhaseBase,
+			Level:   v1alpha2.NotificationLevelInfo,
+			Reason:  reason.NewPodCreation(reason.OperatorSource, []string{"Creating a Jenkins Deployment"}),
+		}
+
+		r.logger.Info(fmt.Sprintf("Creating a new Jenkins Deployment %s/%s", jenkinsDeployment.Namespace, jenkinsDeployment.Name))
+		err := r.CreateResource(jenkinsDeployment)
+		if err != nil {
+			return reconcile.Result{}, stackerr.WithStack(err)
+		}
+
+		now := metav1.Now()
+		r.Configuration.Jenkins.Status = v1alpha2.JenkinsStatus{
+			OperatorVersion:     version.Version,
+			ProvisionStartTime:  &now,
+			LastBackup:          r.Configuration.Jenkins.Status.LastBackup,
+			PendingBackup:       r.Configuration.Jenkins.Status.LastBackup,
+			UserAndPasswordHash: userAndPasswordHash,
+		}
+		return reconcile.Result{Requeue: true}, r.Client.Update(context.TODO(), r.Configuration.Jenkins)
+	} else if err != nil && !apierrors.IsNotFound(err) {
+		return reconcile.Result{}, stackerr.WithStack(err)
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/jenkins/configuration/base/resources/deployment.go
+++ b/pkg/controller/jenkins/configuration/base/resources/deployment.go
@@ -1,0 +1,50 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/jenkinsci/kubernetes-operator/pkg/apis/jenkins/v1alpha2"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+// NewJenkinsMasterPod builds Jenkins Master Kubernetes Pod resource.
+func NewJenkinsDeployment(objectMeta metav1.ObjectMeta, jenkins *v1alpha2.Jenkins) *appsv1.Deployment {
+	serviceAccountName := objectMeta.Name
+	objectMeta.Annotations = jenkins.Spec.Master.Annotations
+	objectMeta.Name = GetJenkinsDeploymentName(jenkins)
+	selector := &metav1.LabelSelector{MatchLabels: objectMeta.Labels}
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      objectMeta.Name,
+			Namespace: objectMeta.Namespace,
+			Labels:    objectMeta.Labels,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32Ptr(1),
+			Strategy: appsv1.DeploymentStrategy{Type: appsv1.RollingUpdateDeploymentStrategyType},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: objectMeta,
+				Spec: corev1.PodSpec{
+					ServiceAccountName: serviceAccountName,
+					NodeSelector:       jenkins.Spec.Master.NodeSelector,
+					Containers:         newContainers(jenkins),
+					Volumes:            append(GetJenkinsMasterPodBaseVolumes(jenkins), jenkins.Spec.Master.Volumes...),
+					SecurityContext:    jenkins.Spec.Master.SecurityContext,
+					ImagePullSecrets:   jenkins.Spec.Master.ImagePullSecrets,
+					Tolerations:        jenkins.Spec.Master.Tolerations,
+					PriorityClassName:  jenkins.Spec.Master.PriorityClassName,
+				},
+			},
+			Selector: selector,
+		},
+	}
+}
+
+// GetJenkinsMasterPodName returns Jenkins pod name for given CR
+func GetJenkinsDeploymentName(jenkins *v1alpha2.Jenkins) string {
+	return fmt.Sprintf("jenkins-%s", jenkins.Name)
+}

--- a/pkg/controller/jenkins/configuration/base/resources/pod.go
+++ b/pkg/controller/jenkins/configuration/base/resources/pod.go
@@ -291,7 +291,7 @@ func newContainers(jenkins *v1alpha2.Jenkins) (containers []corev1.Container) {
 }
 
 // GetJenkinsMasterPodName returns Jenkins pod name for given CR
-func GetJenkinsMasterPodName(jenkins v1alpha2.Jenkins) string {
+func GetJenkinsMasterPodName(jenkins *v1alpha2.Jenkins) string {
 	return fmt.Sprintf("jenkins-%s", jenkins.Name)
 }
 
@@ -313,7 +313,7 @@ func GetJenkinsMasterPodLabels(jenkins v1alpha2.Jenkins) map[string]string {
 func NewJenkinsMasterPod(objectMeta metav1.ObjectMeta, jenkins *v1alpha2.Jenkins) *corev1.Pod {
 	serviceAccountName := objectMeta.Name
 	objectMeta.Annotations = jenkins.Spec.Master.Annotations
-	objectMeta.Name = GetJenkinsMasterPodName(*jenkins)
+	objectMeta.Name = GetJenkinsMasterPodName(jenkins)
 	objectMeta.Labels = GetJenkinsMasterPodLabels(*jenkins)
 
 	return &corev1.Pod{

--- a/pkg/controller/jenkins/configuration/base/validate_test.go
+++ b/pkg/controller/jenkins/configuration/base/validate_test.go
@@ -573,7 +573,7 @@ func TestValidateConfigMapVolume(t *testing.T) {
 
 		baseReconcileLoop := New(configuration.Configuration{
 			Jenkins: &v1alpha2.Jenkins{ObjectMeta: metav1.ObjectMeta{Name: "example"}},
-			Client: fakeClient,
+			Client:  fakeClient,
 		}, client.JenkinsAPIConnectionSettings{})
 
 		got, err := baseReconcileLoop.validateConfigMapVolume(volume)
@@ -652,7 +652,7 @@ func TestValidateSecretVolume(t *testing.T) {
 		fakeClient := fake.NewFakeClient()
 		baseReconcileLoop := New(configuration.Configuration{
 			Jenkins: &v1alpha2.Jenkins{ObjectMeta: metav1.ObjectMeta{Name: "example"}},
-			Client: fakeClient,
+			Client:  fakeClient,
 		}, client.JenkinsAPIConnectionSettings{})
 
 		got, err := baseReconcileLoop.validateSecretVolume(volume)

--- a/test/e2e/jenkins.go
+++ b/test/e2e/jenkins.go
@@ -156,7 +156,7 @@ func createJenkinsCR(t *testing.T, name, namespace string, seedJob *[]v1alpha2.S
 
 func createJenkinsAPIClientFromServiceAccount(t *testing.T, jenkins *v1alpha2.Jenkins, jenkinsAPIURL string) (jenkinsclient.Jenkins, error) {
 	t.Log("Creating Jenkins API client from service account")
-	podName := resources.GetJenkinsMasterPodName(*jenkins)
+	podName := resources.GetJenkinsMasterPodName(jenkins)
 
 	clientSet, err := kubernetes.NewForConfig(framework.Global.KubeConfig)
 	if err != nil {
@@ -197,7 +197,7 @@ func verifyJenkinsAPIConnection(t *testing.T, jenkins *v1alpha2.Jenkins, namespa
 	}, &service)
 	require.NoError(t, err)
 
-	podName := resources.GetJenkinsMasterPodName(*jenkins)
+	podName := resources.GetJenkinsMasterPodName(jenkins)
 	port, cleanUpFunc, waitFunc, portForwardFunc, err := setupPortForwardToPod(t, namespace, podName, int(constants.DefaultHTTPPortInt32))
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Part of refactor for https://github.com/jenkinsci/kubernetes-operator/issues/195

Allows for using the annotation `jenkins.io/use-deployment`
and setting the value to `true` makes the operator use a
Deployment instead of Pod for serving Jenkins.

- Refactor from `base/resources/pod.go` to `base/resources/deployment.go`
- Added conditional creation and reconciliation for Deployement resource if `jenkins.io/use-deployment` annotation is set to `true`

IMPORTANT NOTE:
The dependency on annotation is only temporary and the logic from reconciling with the Pod will be moved completely in the upcoming PRs for refactoring.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
