### PR TITLE
Move plugins installation to init container

### DIFF
--- a/pkg/configuration/base/resources/scripts_configmap.go
+++ b/pkg/configuration/base/resources/scripts_configmap.go
@@ -265,6 +265,12 @@ chmod +x {{ .JenkinsHomePath }}/scripts/*.sh
 {{- $jenkinsHomePath := .JenkinsHomePath }}
 {{- $installPluginsCommand := .InstallPluginsCommand }}
 
+REF=${REF:-%s/plugins}
+OLD_REF=${REF}
+
+cp -r "${REF}"/* "${JENKINS_REF}"
+export REF="${JENKINS_REF}"
+
 echo "Installing plugins required by Operator - begin"
 cat > {{ .JenkinsHomePath }}/base-plugins << EOF
 {{ range $index, $plugin := .BasePlugins }}
@@ -291,6 +297,8 @@ else
   {{ $installPluginsCommand }} {{ .JenkinsHomePath }}/user-plugins
 fi
 echo "Installing plugins required by user - end"
+
+export REF=${OLD_REF}
 `))
 
 func buildConfigMapTypeMeta() metav1.TypeMeta {

--- a/pkg/configuration/base/validate.go
+++ b/pkg/configuration/base/validate.go
@@ -76,7 +76,7 @@ func (r *ReconcileJenkinsBaseConfiguration) validateJenkinsMasterContainerComman
 		return []string{}
 	}
 
-	jenkinsOperatorInitScript := fmt.Sprintf("%s/%s && ", resources.JenkinsScriptsVolumePath, resources.InitScriptName)
+	jenkinsOperatorInitScript := "export REF=${JENKINS_REF} && "
 	correctCommand := []string{
 		"bash",
 		"-c",

--- a/pkg/configuration/base/validate_test.go
+++ b/pkg/configuration/base/validate_test.go
@@ -923,8 +923,7 @@ func TestValidateJenkinsMasterContainerCommand(t *testing.T) {
 							Command: []string{
 								"bash",
 								"-c",
-								fmt.Sprintf("%s/%s && my-extra-command.sh && exec /sbin/tini -s -- /usr/local/bin/jenkins.sh",
-									resources.JenkinsScriptsVolumePath, resources.InitScriptName),
+								"export REF=${JENKINS_REF} && my-extra-command.sh && exec /sbin/tini -s -- /usr/local/bin/jenkins.sh",
 							},
 						},
 					},
@@ -947,8 +946,7 @@ func TestValidateJenkinsMasterContainerCommand(t *testing.T) {
 							Command: []string{
 								"bash",
 								"-c",
-								fmt.Sprintf("%s/%s && my-extra-command.sh && /sbin/tini -s -- /usr/local/bin/jenkins.sh",
-									resources.JenkinsScriptsVolumePath, resources.InitScriptName),
+								"export REF=${JENKINS_REF} && my-extra-command.sh && /sbin/tini -s -- /usr/local/bin/jenkins.sh",
 							},
 						},
 					},


### PR DESCRIPTION
# Changes

Install jenkins plugins in the init container as requested in
https://github.com/jenkinsci/kubernetes-operator/issues/337
Changes introduced in this commit make jenkins-master container
sustainable to readiness/liveness probe failures when downloading
plugins, as plugins are downloaded in separate container (initContainer,
jenkins-init).

Operations with JENKINS_REF and REF, introduced in this commit are
required in order to properly handle custom jenkins images with
pre-installed plugins. Simply using REF path as EmptyDir is not desired
in this case as it will mask all pre-installed plugins in the image and
thus make such `cached` image useless. In order to support such
scenario, a different volume is created, which is later populated with
contents of REF from the image and only afterwards plugins are
installed.

Closes https://github.com/jenkinsci/kubernetes-operator/issues/337

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added) --- existing tests are modified
- [ ] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


# Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

Please let me know what else should I add to make this PR complete.