### PR TITLE
Change helm chart to helm 3 apiVersion

### DIFF
--- a/chart/jenkins-operator/Chart.yaml
+++ b/chart/jenkins-operator/Chart.yaml
@@ -1,6 +1,6 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: "0.4.0"
 description: Kubernetes native operator which fully manages Jenkins on Kubernetes
 name: jenkins-operator
-version: 0.2.4
+version: 0.3.0
 icon: https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/assets/jenkins-operator-icon.png


### PR DESCRIPTION


<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The chart is already in the format of a Helm 3 chart, however the `apiVersion` of the chart is set to `v1`, which is used for Helm 2 charts. Helm 3 charts should use `apiVersion: v2`.

This makes tools such as ArgoCD mistake the chart for a Helm 2 chart, and therefore template the chart using the wrong helm version. In ArgoCDs case, that means that the CRDs aren't deployed.

reference: https://helm.sh/docs/faq/#chartyaml-apiversion-bump

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
