### PR TITLE
Update Status and not the Spec

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -89,6 +89,16 @@ rules:
       - list
       - watch
   - apiGroups:
+      - "route.openshift.io"
+    resources:
+      - routes
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+  - apiGroups:
       - "image.openshift.io"
     resources:
       - imagestreams

--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -2,7 +2,6 @@ package apis
 
 import (
 	"github.com/jenkinsci/kubernetes-operator/pkg/apis/jenkins/v1alpha2"
-
 	"k8s.io/apimachinery/pkg/runtime"
 )
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Currently the Jenkins Status shows no updates when reconciliation is done on
resources. Instead the Spec is overriden and this can cause confusion as there is
loss in data where the User mentioned config is lost as well as the reconciled 
state is not properly saved in the status.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
