### PR TITLE
Check casc version to match changes in YamlSource

### DIFF
--- a/pkg/configuration/user/casc/casc.go
+++ b/pkg/configuration/user/casc/casc.go
@@ -45,29 +45,15 @@ func (c *configurationAsCode) Ensure(jenkins *v1alpha2.Jenkins) (requeue bool, e
 }
 
 const applyConfigurationAsCodeGroovyScriptFmt = `
-import hudson.util.VersionNumber
-
 String[] configContent = ['''%s''']
+
 def configSb = new StringBuffer()
 for (int i=0; i<configContent.size(); i++) {
     configSb << configContent[i]
 }
 
 def stream = new ByteArrayInputStream(configSb.toString().getBytes('UTF-8'))
-
-def plugin = jenkins.model.Jenkins.instance.getPluginManager().whichPlugin(io.jenkins.plugins.casc.ConfigurationAsCode)
-def version = plugin.getVersionNumber()
-
-def source
-
-switch (version) {
-	case { it.isNewerThanOrEqualTo(new VersionNumber("1.41")) }:
-		source = new io.jenkins.plugins.casc.yaml.YamlSource(stream)
-		break
-	default:
-		source = new io.jenkins.plugins.casc.yaml.YamlSource(stream, io.jenkins.plugins.casc.yaml.YamlSource.READ_FROM_INPUTSTREAM)
-		break
-	}
+def source = io.jenkins.plugins.casc.yaml.YamlSource.of(stream)
 
 io.jenkins.plugins.casc.ConfigurationAsCode.get().configureWith(source)
 `


### PR DESCRIPTION
Casc version 1.41 introduced changed to [YamlSource](https://github.com/jenkinsci/configuration-as-code-plugin/blob/configuration-as-code-1.41/plugin/src/main/java/io/jenkins/plugins/casc/yaml/YamlSource.java) which breaks the current implementation in the operator. The commit checks the version of casc and loads the yaml accordingly.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Check casc plugin version, to accommodate for api changes in version casc v1.41 in  [YamlSource](https://github.com/jenkinsci/configuration-as-code-plugin/blob/configuration-as-code-1.41/plugin/src/main/java/io/jenkins/plugins/casc/yaml/YamlSource.java)

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added) 
- [ ] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).