### PR TITLE
travis: remove usuless travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
     - stage: unit
       name: "Jenkins Operator - unit tests"
       script:
-        - travis_wait 15 make verify
+        - make verify
     - stage: e2e
       name: "Backup PVC - e2e"
       script:
@@ -49,15 +49,15 @@ jobs:
       script:
         - sudo apt-get update
         - sudo apt-get install socat
-        - travis_wait 10 make travis-prepare
-        - travis_wait 45 make build e2e
+        - make travis-prepare
+        - make build e2e
     - stage: e2e
       name: "Jenkins Operator Helm Chart - e2e"
       script:
         - sudo apt-get update
         - sudo apt-get install socat
-        - travis_wait 10 make travis-prepare
-        - travis_wait 45 make e2e BUILDTAGS=Helm E2E_TEST_SELECTOR='^.*Helm.*$'
+        - make travis-prepare
+        - make e2e BUILDTAGS=Helm E2E_TEST_SELECTOR='^.*Helm.*$'
 
 cache:
   directories:


### PR DESCRIPTION
travis_wait are used when build commands does not produce output for more than 10 minutes to avoid them to be killed.
travis_wait will launch them in bacground and poll for their stdout insteand of displaying the stdout directly which is masking the logs during the run.

by removing this directive, we should see live logs for the `make e2e` command and others.
