### PR TITLE
Parameterised liveness and readiness probe in helm chart

### DIFF
--- a/chart/jenkins-operator/templates/jenkins.yaml
+++ b/chart/jenkins-operator/templates/jenkins.yaml
@@ -83,26 +83,30 @@ spec:
         {{- with .Values.jenkins.imagePullSecrets }}
         imagePullSecrets: {{ toYaml . | nindent 10 }}
         {{- end }}
+        {{- if .Values.jenkins.livenessProbe.enabled }}
         livenessProbe:
-          failureThreshold: 12
+          failureThreshold: {{ .Values.jenkins.livenessProbe.failureThreshold }}
           httpGet:
-            path: /login
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 80
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 5
+            path: {{ .Values.jenkins.livenessProbe.httpGet.path }}
+            port: {{ .Values.jenkins.livenessProbe.httpGet.port }}
+            scheme: {{ .Values.jenkins.livenessProbe.httpGet.scheme }}
+          initialDelaySeconds: {{ .Values.jenkins.livenessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.jenkins.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.jenkins.livenessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.jenkins.livenessProbe.timeoutSeconds }}
+        {{- end }}
+        {{- if .Values.jenkins.readinessProbe.enabled }}
         readinessProbe:
-          failureThreshold: 3
+          failureThreshold: {{ .Values.jenkins.readinessProbe.failureThreshold }}
           httpGet:
-            path: /login
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
+            path: {{ .Values.jenkins.readinessProbe.httpGet.path }}
+            port: {{ .Values.jenkins.readinessProbe.httpGet.port }}
+            scheme: {{ .Values.jenkins.readinessProbe.httpGet.scheme }}
+          initialDelaySeconds: {{ .Values.jenkins.readinessProbe.initialDelaySeconds }}
+          periodSeconds: {{ .Values.jenkins.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.jenkins.readinessProbe.successThreshold }}
+          timeoutSeconds: {{ .Values.jenkins.readinessProbe.timeoutSeconds }}
+        {{- end }}
         {{- with .Values.jenkins.resources }}
         resources: {{ toYaml . | nindent 10 }}
         {{- end }}

--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -33,6 +33,32 @@ jenkins:
 
   # imagePullPolicy defines policy for pulling images
   imagePullPolicy: Always
+  
+  # livenessProbe of Jenkins instance
+  livenessProbe:
+    enabled: true
+    failureThreshold: 12
+    httpGet:
+      path: /login
+      port: http
+      scheme: HTTP
+    initialDelaySeconds: 80
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+
+  # readinessProbe of Jenkins instance
+  readinessProbe:
+    enabled: true
+    failureThreshold: 3
+    httpGet:
+      path: /login
+      port: http
+      scheme: HTTP
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
 
   # priorityClassName indicates the importance of a Pod relative to other Pods
   # See: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/


### PR DESCRIPTION
The jenkins master config accepted by the operator has the liveness and
readiness probe already parameterised. This however has been hard coded
in the helm chart implementation for this operator. I have just moved
the values to be set using variables from values.yaml file. I have also
added an enable option so that the user of the chart may implement the
probes as per their volition.

Additionally this comes in handy if the no of plugins to be installed is
high and causes the jenkins master to terminate immaturely due to probe
timeout. Ideally the plugins must be installed via an init container but
given that the pr #393 to implement that is in stale state, I have
raised this pr to be a workaround to this issue.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
liveness and readiness probe of jenkins instance can be configured from the values.yaml file of helm chart for the jenkins operator
```
