### PR TITLE
Added labels and annotations to Helm Chart

### DIFF
--- a/chart/jenkins-operator/templates/jenkins.yaml
+++ b/chart/jenkins-operator/templates/jenkins.yaml
@@ -7,6 +7,9 @@ metadata:
   {{- with .Values.jenkins.labels }}
   labels: {{ toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.jenkins.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   configurationAsCode:
     configurations:
@@ -67,6 +70,9 @@ spec:
   master:
     {{- with .Values.jenkins.labels }}
     labels: {{ toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with .Values.jenkins.annotations }}
+    annotations: {{ toYaml . | nindent 6 }}
     {{- end }}
     {{- with .Values.jenkins.basePlugins }}
     basePlugins: {{ toYaml . | nindent 4 }}
@@ -133,4 +139,4 @@ spec:
   {{- with .Values.jenkins.seedJobs }}
   seedJobs: {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- end }}
+  {{- end }}

--- a/chart/jenkins-operator/templates/jenkins.yaml
+++ b/chart/jenkins-operator/templates/jenkins.yaml
@@ -7,9 +7,6 @@ metadata:
   {{- with .Values.jenkins.labels }}
   labels: {{ toYaml . | nindent 4 }}
   {{- end }}
-  {{- with .Values.jenkins.annotations }}
-  annotations: {{ toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   configurationAsCode:
     configurations:
@@ -139,4 +136,4 @@ spec:
   {{- with .Values.jenkins.seedJobs }}
   seedJobs: {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- end }}
+{{- end }}

--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -23,6 +23,9 @@ jenkins:
   # labels are injected into metadata labels field
   labels: {}
 
+  # annotations are injected into metadata annotations field
+  annotations: {}
+
   # image is the name (and tag) of the Jenkins instance
   # Default: jenkins/jenkins:lts
   # It's recommended to use LTS (tag: "lts") version

--- a/website/content/en/docs/Installation/_index.md
+++ b/website/content/en/docs/Installation/_index.md
@@ -56,5 +56,11 @@ To install, you need only to type these commands:
 
 ```bash
 $ helm repo add jenkins https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/chart
-$ helm install jenkins/jenkins-operator
+$ helm install <name> jenkins/jenkins-operator
+```
+
+To add custom labels and annotations, you can use `values.yaml` file or pass them into `helm install` command, e.g.:
+
+```bash
+$ helm install <name> jenkins/jenkins-operator --set jenkins.labels.LabelKey=LabelValue,jenkins.annotations.AnnotationKey=AnnotationValue
 ```


### PR DESCRIPTION
Added configuration option for the user to specify annotations and labels for Jenkins CR and pod via helm. Updated installation guide with information about this feature.
#432 