### PR TITLE
Change footer website copyrights

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -92,7 +92,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -140,7 +140,7 @@ Jenkins Operator is a Kubernetes native operator which fully manages Jenkins on 
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/blog/2018/01/04/another-great-release/index.html
+++ b/docs/blog/2018/01/04/another-great-release/index.html
@@ -656,7 +656,7 @@ This is a warning with a title!
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/blog/2018/10/06/easy-documentation-with-docsy/index.html
+++ b/docs/blog/2018/10/06/easy-documentation-with-docsy/index.html
@@ -310,7 +310,7 @@ Fetch and scale an image in the upcoming Hugo 0.43.
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/blog/2018/10/06/the-second-blog-post/index.html
+++ b/docs/blog/2018/10/06/the-second-blog-post/index.html
@@ -656,7 +656,7 @@ This is a warning with a title!
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -306,7 +306,7 @@ There should be whitespace between paragraphs. There should be whitespace betwee
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/blog/news/index.html
+++ b/docs/blog/news/index.html
@@ -290,7 +290,7 @@ Including images Here&rsquo;s an image …</p>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/blog/releases/index.html
+++ b/docs/blog/releases/index.html
@@ -265,7 +265,7 @@ There should be whitespace between paragraphs. There should be whitespace betwee
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/community/index.html
+++ b/docs/community/index.html
@@ -120,7 +120,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/developer-guide/index.html
+++ b/docs/docs/developer-guide/index.html
@@ -1019,7 +1019,7 @@ kubectl get secret jenkins-operator-credentials-&lt;cr_name&gt; -o <span style="
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/developer-guide/tools/index.html
+++ b/docs/docs/developer-guide/tools/index.html
@@ -709,7 +709,7 @@ go install</code></pre>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/index.html
+++ b/docs/docs/getting-started/index.html
@@ -800,7 +800,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/latest/aks/index.html
+++ b/docs/docs/getting-started/latest/aks/index.html
@@ -680,7 +680,7 @@ restart of a Jenkins pod over and over again.</p>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/latest/configuration/index.html
+++ b/docs/docs/getting-started/latest/configuration/index.html
@@ -967,7 +967,7 @@ stringData:
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/latest/configure-backup-and-restore/index.html
+++ b/docs/docs/getting-started/latest/configure-backup-and-restore/index.html
@@ -756,7 +756,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/latest/custom-backup-and-restore/index.html
+++ b/docs/docs/getting-started/latest/custom-backup-and-restore/index.html
@@ -852,7 +852,7 @@ the number of backups under control, e.g. Cloud Formation fragment:</p>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/latest/customization/index.html
+++ b/docs/docs/getting-started/latest/customization/index.html
@@ -854,7 +854,7 @@ The secrets are loaded to <code>secrets</code> map.</p>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/latest/deploy-jenkins/index.html
+++ b/docs/docs/getting-started/latest/deploy-jenkins/index.html
@@ -728,7 +728,7 @@ kubectl get secret jenkins-operator-credentials-&lt;cr_name&gt; -o <span style="
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/latest/diagnostics/index.html
+++ b/docs/docs/getting-started/latest/diagnostics/index.html
@@ -685,7 +685,7 @@ kubectl apply -f deploy/operator.yaml</code></pre></div>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/latest/index.html
+++ b/docs/docs/getting-started/latest/index.html
@@ -858,7 +858,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/latest/notifications/index.html
+++ b/docs/docs/getting-started/latest/notifications/index.html
@@ -773,7 +773,7 @@ spec:
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/latest/openshift/index.html
+++ b/docs/docs/getting-started/latest/openshift/index.html
@@ -775,7 +775,7 @@ OpenShift oauth authentication. By default, the jenkins http service is named
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/latest/schema/index.html
+++ b/docs/docs/getting-started/latest/schema/index.html
@@ -3291,7 +3291,7 @@ on git commit <code>1c853e69</code>.
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.1.x/aks/index.html
+++ b/docs/docs/getting-started/v0.1.x/aks/index.html
@@ -680,7 +680,7 @@ the restart of a Jenkins pod over and over again.</p>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.1.x/configuration/index.html
+++ b/docs/docs/getting-started/v0.1.x/configuration/index.html
@@ -917,7 +917,7 @@ The <code>/sbin/tini -s -- /usr/local/bin/jenkins.sh</code> command runs the Jen
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.1.x/configure-backup-and-restore/index.html
+++ b/docs/docs/getting-started/v0.1.x/configure-backup-and-restore/index.html
@@ -754,7 +754,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.1.x/customization/index.html
+++ b/docs/docs/getting-started/v0.1.x/customization/index.html
@@ -761,7 +761,7 @@ spec:
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.1.x/deploy-jenkins/index.html
+++ b/docs/docs/getting-started/v0.1.x/deploy-jenkins/index.html
@@ -733,7 +733,7 @@ kubectl get secret jenkins-operator-credentials-&lt;cr_name&gt; -o <span style="
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.1.x/diagnostics/index.html
+++ b/docs/docs/getting-started/v0.1.x/diagnostics/index.html
@@ -685,7 +685,7 @@ kubectl apply -f deploy/operator.yaml</code></pre></div>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.1.x/index.html
+++ b/docs/docs/getting-started/v0.1.x/index.html
@@ -842,7 +842,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.1.x/migration-guide-v1alpha1-to-v1alpha2/index.html
+++ b/docs/docs/getting-started/v0.1.x/migration-guide-v1alpha1-to-v1alpha2/index.html
@@ -979,7 +979,7 @@ or use the default deployment manifest:</p>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.1.x/scheme/index.html
+++ b/docs/docs/getting-started/v0.1.x/scheme/index.html
@@ -2106,7 +2106,7 @@ on git commit <code>37e531a</code>.
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.2.x/aks/index.html
+++ b/docs/docs/getting-started/v0.2.x/aks/index.html
@@ -680,7 +680,7 @@ restart of a Jenkins pod over and over again.</p>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.2.x/configuration/index.html
+++ b/docs/docs/getting-started/v0.2.x/configuration/index.html
@@ -958,7 +958,7 @@ stringData:
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.2.x/configure-backup-and-restore/index.html
+++ b/docs/docs/getting-started/v0.2.x/configure-backup-and-restore/index.html
@@ -756,7 +756,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.2.x/custom-backup-and-restore/index.html
+++ b/docs/docs/getting-started/v0.2.x/custom-backup-and-restore/index.html
@@ -852,7 +852,7 @@ the number of backups under control, e.g. Cloud Formation fragment:</p>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.2.x/customization/index.html
+++ b/docs/docs/getting-started/v0.2.x/customization/index.html
@@ -832,7 +832,7 @@ spec:
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.2.x/deploy-jenkins/index.html
+++ b/docs/docs/getting-started/v0.2.x/deploy-jenkins/index.html
@@ -727,7 +727,7 @@ kubectl get secret jenkins-operator-credentials-&lt;cr_name&gt; -o <span style="
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.2.x/diagnostics/index.html
+++ b/docs/docs/getting-started/v0.2.x/diagnostics/index.html
@@ -685,7 +685,7 @@ kubectl apply -f deploy/operator.yaml</code></pre></div>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.2.x/index.html
+++ b/docs/docs/getting-started/v0.2.x/index.html
@@ -850,7 +850,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.2.x/migration/index.html
+++ b/docs/docs/getting-started/v0.2.x/migration/index.html
@@ -739,7 +739,7 @@ and add explicit references to the existing <code>ConfigMap</code> and <code>Sec
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.2.x/schema/index.html
+++ b/docs/docs/getting-started/v0.2.x/schema/index.html
@@ -2641,7 +2641,7 @@ on git commit <code>f4c4235</code>.
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.3.x/aks/index.html
+++ b/docs/docs/getting-started/v0.3.x/aks/index.html
@@ -680,7 +680,7 @@ restart of a Jenkins pod over and over again.</p>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.3.x/configuration/index.html
+++ b/docs/docs/getting-started/v0.3.x/configuration/index.html
@@ -958,7 +958,7 @@ stringData:
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.3.x/configure-backup-and-restore/index.html
+++ b/docs/docs/getting-started/v0.3.x/configure-backup-and-restore/index.html
@@ -756,7 +756,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.3.x/custom-backup-and-restore/index.html
+++ b/docs/docs/getting-started/v0.3.x/custom-backup-and-restore/index.html
@@ -852,7 +852,7 @@ the number of backups under control, e.g. Cloud Formation fragment:</p>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.3.x/customization/index.html
+++ b/docs/docs/getting-started/v0.3.x/customization/index.html
@@ -832,7 +832,7 @@ spec:
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.3.x/deploy-jenkins/index.html
+++ b/docs/docs/getting-started/v0.3.x/deploy-jenkins/index.html
@@ -728,7 +728,7 @@ kubectl get secret jenkins-operator-credentials-&lt;cr_name&gt; -o <span style="
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.3.x/diagnostics/index.html
+++ b/docs/docs/getting-started/v0.3.x/diagnostics/index.html
@@ -685,7 +685,7 @@ kubectl apply -f deploy/operator.yaml</code></pre></div>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.3.x/index.html
+++ b/docs/docs/getting-started/v0.3.x/index.html
@@ -858,7 +858,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.3.x/migration/index.html
+++ b/docs/docs/getting-started/v0.3.x/migration/index.html
@@ -694,7 +694,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.3.x/notifications/index.html
+++ b/docs/docs/getting-started/v0.3.x/notifications/index.html
@@ -773,7 +773,7 @@ spec:
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/getting-started/v0.3.x/schema/index.html
+++ b/docs/docs/getting-started/v0.3.x/schema/index.html
@@ -2835,7 +2835,7 @@ on git commit <code>4b89360</code>.
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/how-it-works/architecture-and-design/index.html
+++ b/docs/docs/how-it-works/architecture-and-design/index.html
@@ -697,7 +697,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/how-it-works/index.html
+++ b/docs/docs/how-it-works/index.html
@@ -774,7 +774,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/how-it-works/jenkins-docker-images/index.html
+++ b/docs/docs/how-it-works/jenkins-docker-images/index.html
@@ -662,7 +662,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/index.html
+++ b/docs/docs/index.html
@@ -785,7 +785,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/installation/index.html
+++ b/docs/docs/installation/index.html
@@ -1576,7 +1576,7 @@ Example:<br />
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/docs/security/index.html
+++ b/docs/docs/security/index.html
@@ -853,7 +853,7 @@ $ kubectl -n jenkins apply -f role_binding_jenkins.yaml</code></pre></div>
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/index.html
+++ b/docs/index.html
@@ -252,7 +252,7 @@
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -110,7 +110,7 @@ s.parentNode.insertBefore(gcse, s);
         
       </div>
       <div class="col-12 col-sm-12 text-center py-4 order-sm-2">
-        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2.</small><br>
+        <small class="text-white">&copy; 2020 Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0.</small><br>
         <small class="text-white">Jenkins® is a registered trademark of Software in the Public Interest, Inc.</small>
 	
 		<p class="mt-2"><a href="/kubernetes-operator/about/">What&#39;s the Jenkins Operator?</a></p>

--- a/website/themes/docsy/i18n/en.toml
+++ b/website/themes/docsy/i18n/en.toml
@@ -23,7 +23,7 @@ other = "in"
 other = "All Rights Reserved"
 
 [footer_vl_license]
-other = "Jenkins Operator is created by VirtusLab. Source and website content is available under Apache License Version 2."
+other = "Jenkins Operator is created by VirtusLab. Source is available under Apache License Version 2 and website content under Creative Commons Attribution-ShareAlike 4.0."
 [footer_according_to_trademark]
 other = "Jenkins® is a registered trademark of Software in the Public Interest, Inc."
 


### PR DESCRIPTION
Divided licenses for source and website content in the footer into Apache License Version 2 and Creative Commons Attribution-ShareAlike 4.0.
