### PR TITLE
Seed jobs can not clone repositories which contain lfs files.

### DIFF
--- a/pkg/configuration/user/seedjobs/seedjobs.go
+++ b/pkg/configuration/user/seedjobs/seedjobs.go
@@ -79,6 +79,7 @@ import hudson.plugins.git.BranchSpec;
 import hudson.plugins.git.GitSCM;
 import hudson.plugins.git.SubmoduleConfig;
 import hudson.plugins.git.extensions.impl.CloneOption;
+import hudson.plugins.git.extensions.impl.GitLFSPull;
 import javaposse.jobdsl.plugin.ExecuteDslScripts;
 import javaposse.jobdsl.plugin.LookupStrategy;
 import javaposse.jobdsl.plugin.RemovedJobAction;
@@ -92,7 +93,10 @@ def jobDslSeedName = "{{ .ID }}-{{ .SeedJobSuffix }}";
 def jobRef = jenkins.getItem(jobDslSeedName)
 
 def repoList = GitSCM.createRepoList("{{ .RepositoryURL }}", "{{ .CredentialID }}")
-def gitExtensions = [new CloneOption(true, true, ";", 10)]
+def gitExtensions = [
+	new CloneOption(true, true, ";", 10),
+	new GitLFSPull()
+]
 def scm = new GitSCM(
         repoList,
         newArrayList(new BranchSpec("{{ .RepositoryBranch }}")),


### PR DESCRIPTION
We now add GitLFS pull after checkout behaviour in order to support also repositories which are relying on Git LFS.

Closes #482

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Seed jobs can not clone repositories which contain lfs files.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

N/A

# Release Notes

N/A