### PR TITLE
Refactor/#498

### DIFF
--- a/chart/jenkins-operator/templates/jenkins.yaml
+++ b/chart/jenkins-operator/templates/jenkins.yaml
@@ -86,26 +86,12 @@ spec:
         {{- with .Values.jenkins.imagePullSecrets }}
         imagePullSecrets: {{ toYaml . | nindent 10 }}
         {{- end }}
-        livenessProbe:
-          failureThreshold: 12
-          httpGet:
-            path: /login
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 80
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 5
-        readinessProbe:
-          failureThreshold: 3
-          httpGet:
-            path: /login
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 10
-          successThreshold: 1
-          timeoutSeconds: 1
+        {{- with .Values.jenkins.livenessProbe }}
+        livenessProbe: {{ toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.jenkins.readinessProbe }}
+        readinessProbe: {{ toYaml . | nindent 10 }}
+        {{- end }}
         {{- with .Values.jenkins.resources }}
         resources: {{ toYaml . | nindent 10 }}
         {{- end }}

--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -147,6 +147,29 @@ jenkins:
   # slave Jenkins service
   # See https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/schema/#github.com/jenkinsci/kubernetes-operator/pkg/apis/jenkins/v1alpha2.Service for details
   #slaveService:
+  
+  # LivenessProbe for Jenkins Master pod
+  livenessProbe:
+    failureThreshold: 12
+    httpGet:
+      path: /login
+      port: http
+      scheme: HTTP
+    initialDelaySeconds: 80
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 5
+  # ReadinessProbe for Jenkins Master pod
+  readinessProbe:
+    failureThreshold: 3
+    httpGet:
+      path: /login
+      port: http
+      scheme: HTTP
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 1
 
   # backup is section for configuring operator's backup feature
   # By default backup feature is enabled and pre-configured

--- a/website/content/en/docs/Installation/_index.md
+++ b/website/content/en/docs/Installation/_index.md
@@ -385,6 +385,50 @@ SecurityContext for pod.
 </tr>
 <tr>
 <td>
+<code>livenessProbe</code>
+</td>
+<td>
+<pre>
+livenessProbe:
+  failureThreshold: 12
+  httpGet:
+    path: /login
+    port: http
+    scheme: HTTP
+  initialDelaySeconds: 80
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 5
+</pre>
+</td>
+<td>
+livenessProbe for Pod
+</td>
+</tr>
+<tr>
+<td>
+<code>readinessProbe</code>
+</td>
+<td>
+<pre>
+readinessProbe:
+  failureThreshold: 3
+  httpGet:
+    path: /login
+    port: http
+    scheme: HTTP
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  successThreshold: 1
+  timeoutSeconds: 1
+</pre>
+</td>
+<td>
+readinessProbe for Pod
+</td>
+</tr>
+<tr>
+<td>
 <code>
 backup
 </code>


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

- Change livenessProbe and readinessProbe as configurable in Helm chart template.
- Add the configurations to web document.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

Helm template update and web document update only. It didn't touch any core features.

# Release Notes

```
- Helm Template change. `livenessProbe` and `readinessProbe` become configurable in the Helm installation. Default value is still same as current static configurations.
```
