### PR TITLE
Pass getLatestAction Helm value to the Jenkins instance

### DIFF
--- a/chart/jenkins-operator/templates/jenkins.yaml
+++ b/chart/jenkins-operator/templates/jenkins.yaml
@@ -51,6 +51,13 @@ spec:
         {{- with .Values.jenkins.backup.restoreCommand }}
         command: {{ toYaml . | nindent 8 }}
         {{- end }}
+    {{- if .Values.jenkins.backup.getLatestAction }}
+    getLatestAction:
+      exec:
+        {{- with .Values.jenkins.backup.getLatestAction }}
+        command: {{ toYaml . | nindent 8 }}
+        {{- end }}
+    {{- end }}
     {{- if .Values.jenkins.backup.recoveryOnce }}
     recoveryOnce: {{ .Values.jenkins.backup.recoveryOnce }}
     {{- end }}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Small addition the the Helm Jenkins instance file. `getLatestAction` variable is not passed event though it is defined in `values.yaml`.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

