### PR TITLE
#539 Allow More SSH Private Key Formats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/robfig/cron v1.2.0
 	github.com/stretchr/testify v1.6.1
 	go.uber.org/zap v1.15.0
+	golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20160411212932-81ebce5c23df
 	k8s.io/api v0.20.2


### PR DESCRIPTION
Reported in #539.

Changed the way the operator is performing ssh private key validation. It will now use `ssh.ParseRawPrivateKey` to validate the key. This allows the user to use keys **other** than PEM encoded RSA. 

ed25519 is often recommended to be used if it's supported. Using this algorithm implies the use of OpenSSH key format in ssh-keygen.

