### PR TITLE
Skip kube-api-access Volume Comparison

### DIFF
--- a/pkg/configuration/base/reconciler.go
+++ b/pkg/configuration/base/reconciler.go
@@ -297,8 +297,8 @@ func (r *JenkinsBaseConfigurationReconciler) compareVolumes(actualPod corev1.Pod
 		}
 
 		// hotfix for k8s 1.21 - filter out kube-api-access-<random-suffix>
-		const kubeApiAccessPrefix = "kube-api-access-"
-		if strings.HasPrefix(volume.Name, kubeApiAccessPrefix) {
+		const kubeAPIAccessPrefix = "kube-api-access-"
+		if strings.HasPrefix(volume.Name, kubeAPIAccessPrefix) {
 			continue
 		}
 

--- a/pkg/configuration/base/reconciler.go
+++ b/pkg/configuration/base/reconciler.go
@@ -289,16 +289,25 @@ func CompareContainerVolumeMounts(expected corev1.Container, actual corev1.Conta
 
 // compareVolumes returns true if Jenkins pod and Jenkins CR volumes are the same
 func (r *JenkinsBaseConfigurationReconciler) compareVolumes(actualPod corev1.Pod) bool {
-	var withoutServiceAccount []corev1.Volume
+	var toCompare []corev1.Volume
 	for _, volume := range actualPod.Spec.Volumes {
-		if !strings.HasPrefix(volume.Name, actualPod.Spec.ServiceAccountName) {
-			withoutServiceAccount = append(withoutServiceAccount, volume)
+		// filter out service account
+		if strings.HasPrefix(volume.Name, actualPod.Spec.ServiceAccountName) {
+			continue
 		}
+
+		// hotfix for k8s 1.21 - filter out kube-api-access-<random-suffix>
+		const kubeApiAccessPrefix = "kube-api-access-"
+		if strings.HasPrefix(volume.Name, kubeApiAccessPrefix) {
+			continue
+		}
+
+		toCompare = append(toCompare, volume)
 	}
 
 	return reflect.DeepEqual(
 		append(resources.GetJenkinsMasterPodBaseVolumes(r.Configuration.Jenkins), r.Configuration.Jenkins.Spec.Master.Volumes...),
-		withoutServiceAccount,
+		toCompare,
 	)
 }
 


### PR DESCRIPTION
Hotfix for the incompatibility between the Operator and Kubernetes 1.21.

Kubernetes in 1.21 ships with `BoundServiceAccountTokenVolume` enabled, which causes the service account admission controller to add a new volume: `kube-api-access-<random-suffix>`. That is causing the operator to loop over comparing the actual and expected volumes. Now that new volume will not be compared.

Kubernetes reference: https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#bound-service-account-token-volume

