### PR TITLE
#552 Seed Jobs: Don't Validate "external" Credential Type

### DIFF
--- a/pkg/configuration/user/seedjobs/validate.go
+++ b/pkg/configuration/user/seedjobs/validate.go
@@ -55,8 +55,7 @@ func (s *seedJobs) ValidateSeedJobs(jenkins v1alpha2.Jenkins) ([]string, error) 
 		}
 
 		if seedJob.JenkinsCredentialType == v1alpha2.BasicSSHCredentialType ||
-			seedJob.JenkinsCredentialType == v1alpha2.UsernamePasswordCredentialType ||
-			seedJob.JenkinsCredentialType == v1alpha2.ExternalCredentialType {
+			seedJob.JenkinsCredentialType == v1alpha2.UsernamePasswordCredentialType {
 			secret := &v1.Secret{}
 			namespaceName := types.NamespacedName{Namespace: jenkins.Namespace, Name: seedJob.CredentialID}
 			err := s.Client.Get(context.TODO(), namespaceName, secret)

--- a/website/content/en/docs/Getting Started/Preview/configuration.md
+++ b/website/content/en/docs/Getting Started/Preview/configuration.md
@@ -221,6 +221,26 @@ stringData:
 ### External authentication
 You can use `external` credential type if you want to configure authentication using Configuration As Code or Groovy Script.
 
+Example:
+```yaml
+apiVersion: jenkins.io/v1alpha2
+kind: Jenkins
+metadata:
+  name: example
+spec:
+  seedJobs:
+  - id: jenkins-operator-external
+    credentialType: external
+    credentialID: k8s-external
+    targets: "cicd/jobs/*.jenkins"
+    description: "Jenkins Operator repository"
+    repositoryBranch: master
+    repositoryUrl: https://github.com/jenkinsci/kubernetes-operator.git
+```
+
+Remember that `credentialID` must match the id of the credentials configured in Jenkins. Consult the
+[Jenkins docs for using credentials][jenkins-using-credentials] for details.
+
 ## HTTP Proxy for downloading plugins
 
 To use forwarding proxy with an operator to download plugins you need to add the following environment variable to Jenkins Custom Resource (CR), e.g.:
@@ -313,3 +333,4 @@ Example config file to modify and use:
 
 [job-dsl]:https://github.com/jenkinsci/job-dsl-plugin
 [kubernetes-credentials-provider]:https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/
+[jenkins-using-credentials]:https://www.jenkins.io/doc/book/using/using-credentials/

--- a/website/content/en/docs/Getting Started/latest/configuration.md
+++ b/website/content/en/docs/Getting Started/latest/configuration.md
@@ -221,6 +221,26 @@ stringData:
 ### External authentication
 You can use `external` credential type if you want to configure authentication using Configuration As Code or Groovy Script.
 
+Example:
+```yaml
+apiVersion: jenkins.io/v1alpha2
+kind: Jenkins
+metadata:
+  name: example
+spec:
+  seedJobs:
+  - id: jenkins-operator-external
+    credentialType: external
+    credentialID: k8s-external
+    targets: "cicd/jobs/*.jenkins"
+    description: "Jenkins Operator repository"
+    repositoryBranch: master
+    repositoryUrl: https://github.com/jenkinsci/kubernetes-operator.git
+```
+
+Remember that `credentialID` must match the id of the credentials configured in Jenkins. Consult the
+[Jenkins docs for using credentials][jenkins-using-credentials] for details.
+
 ## HTTP Proxy for downloading plugins
 
 To use forwarding proxy with an operator to download plugins you need to add the following environment variable to Jenkins Custom Resource (CR), e.g.:
@@ -313,3 +333,4 @@ Example config file to modify and use:
 
 [job-dsl]:https://github.com/jenkinsci/job-dsl-plugin
 [kubernetes-credentials-provider]:https://jenkinsci.github.io/kubernetes-credentials-provider-plugin/
+[jenkins-using-credentials]:https://www.jenkins.io/doc/book/using/using-credentials/


### PR DESCRIPTION
Reported in: https://github.com/jenkinsci/kubernetes-operator/issues/552

Fixes a problem where the operator tries to look for `external` credential type in Kubernetes secrets and fails.

The operator shouldn't try to fetch credentials that have their types defined as `external` - that means that credentials are supplied externally, without using k8s secrets (using e.g. Configuration As Code or Groovy Script).

Docs: https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/configuration/#external-authentication
