### PR TITLE
update kubernetes to 1.30.0

### DIFF
--- a/pkg/plugins/base_plugins.go
+++ b/pkg/plugins/base_plugins.go
@@ -5,7 +5,7 @@ const (
 	gitPlugin                           = "git:4.7.2"
 	jobDslPlugin                        = "job-dsl:1.77"
 	kubernetesCredentialsProviderPlugin = "kubernetes-credentials-provider:0.18-1"
-	kubernetesPlugin                    = "kubernetes:1.29.6"
+	kubernetesPlugin                    = "kubernetes:1.30.0"
 	workflowAggregatorPlugin            = "workflow-aggregator:2.6"
 	workflowJobPlugin                   = "workflow-job:2.41"
 )


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Update Kubernetes Plugin to 1.30.0. The sub-plugin `kubernetes-client-api` has released it's major version 5.4.1 which is not compatible with `kubernetes:1.29.6`, but unfortunately the startup script of the jenkins will install `kubernetes-client-api:5.4.1` which ends up in all kind of strange issues. Like for us it started to endlessly create pods because of this error:
`java.lang.NoSuchMethodError: io.fabric8.kubernetes.client.dsl.PodResource.watch`

I tested this with adding 
```
  basePlugins:
    - name: kubernetes
      version: 1.30.0
    - name: workflow-job
      version: '2.41'
    - name: workflow-aggregator
      version: '2.6'
    - name: git
      version: 4.7.2
    - name: job-dsl
      version: '1.77'
    - name: configuration-as-code
      version: '1.51'
    - name: kubernetes-credentials-provider
      version: 0.18-1
``` 

to the helmfiles and after that it all works again.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
