### PR TITLE
Bump seedjobs agent image version to 4.9-1

### DIFF
--- a/pkg/configuration/user/seedjobs/seedjobs.go
+++ b/pkg/configuration/user/seedjobs/seedjobs.go
@@ -438,7 +438,7 @@ func agentDeployment(jenkins *v1alpha2.Jenkins, namespace string, agentName stri
 					Containers: []corev1.Container{
 						{
 							Name:  "jnlp",
-							Image: "jenkins/inbound-agent:alpine",
+							Image: "jenkins/inbound-agent:4.9-1",
 							Env: []corev1.EnvVar{
 								{
 									Name: "JENKINS_TUNNEL",


### PR DESCRIPTION
Should fix seedjob agent's problems with DNS reported in https://github.com/jenkinsci/kubernetes-operator/issues/528
