### PR TITLE
Add handling of empty WATCH_NAMESPACE value of jenkins.namespace 

### DIFF
--- a/chart/jenkins-operator/Chart.yaml
+++ b/chart/jenkins-operator/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 appVersion: "0.6.0"
 description: Kubernetes native operator which fully manages Jenkins on Kubernetes
 name: jenkins-operator
-version: 0.5.1
+version: 0.5.2
 icon: https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/assets/jenkins-operator-icon.png

--- a/chart/jenkins-operator/templates/_role.yaml
+++ b/chart/jenkins-operator/templates/_role.yaml
@@ -1,11 +1,13 @@
 {{ define "jenkins-operator.role" }}
 {{ $namespace := . }}
 ---
-kind: Role
+kind: {{ if eq $namespace "" }}ClusterRole{{ else }}Role{{ end }}
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: jenkins-operator
+{{- if ne $namespace "" }}
   namespace: {{ $namespace }}
+{{- end }}
 rules:
   - apiGroups:
       - apps

--- a/chart/jenkins-operator/templates/role_binding.yaml
+++ b/chart/jenkins-operator/templates/role_binding.yaml
@@ -12,7 +12,28 @@ roleRef:
   kind: Role
   name: jenkins-operator
   apiGroup: rbac.authorization.k8s.io
-{{ if ne .Release.Namespace .Values.jenkins.namespace }}
+{{ if eq .Values.jenkins.namespace "" }}
+{{- /*
+# This is a special case when .Values.jenkins.namespace is equal to empty
+# string which leads to WATCH_NAMESPACE env of jenkins-operator to be set of
+# empty string and leads to operator actually watching all namespaces. In this
+# case we need to create clusterrole and clusterrolebinding instead of role and
+# rolebinding
+*/}}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jenkins-operator
+subjects:
+  - kind: ServiceAccount
+    name: jenkins-operator
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: jenkins-operator
+  apiGroup: rbac.authorization.k8s.io
+{{ else if ne .Release.Namespace .Values.jenkins.namespace }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/chart/jenkins-operator/templates/role_binding.yaml
+++ b/chart/jenkins-operator/templates/role_binding.yaml
@@ -15,7 +15,7 @@ roleRef:
 {{ if eq .Values.jenkins.namespace "" }}
 {{- /*
 # This is a special case when .Values.jenkins.namespace is equal to empty
-# string which leads to WATCH_NAMESPACE env of jenkins-operator to be set of
+# string which leads to WATCH_NAMESPACE env of jenkins-operator to be set to
 # empty string and leads to operator actually watching all namespaces. In this
 # case we need to create clusterrole and clusterrolebinding instead of role and
 # rolebinding

--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -18,6 +18,7 @@ jenkins:
   # namespace is the namespace where the resources will be deployed
   # It's not recommended to use default namespace
   # Create new namespace for jenkins (called e.g. jenkins)
+  # Note: this affects roles and rolebindings for jenkins operator itself
   namespace: default
 
   # labels are injected into metadata labels field
@@ -136,7 +137,7 @@ jenkins:
   # slave Jenkins service
   # See https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/schema/#github.com/jenkinsci/kubernetes-operator/pkg/apis/jenkins/v1alpha2.Service for details
   #slaveService:
-  
+
   # LivenessProbe for Jenkins Master pod
   livenessProbe:
     failureThreshold: 12


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

If jenkins.namespace is set to "", it leads to WATCH_NAMESPACE
environment value of Jenkins Operator itself to be set to "", which
leads that operator watches all namespaces (see
#77 (comment)).
This case requires custom handling: instead of creating role and
role_binding we need to create clusterrole and clusterrolebinding with
the required permissions.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
If jenkins.namespace is set to "", it leads to WATCH_NAMESPACE
environment value of Jenkins Operator itself to be set to "", which
leads that operator watches all namespaces (see
#77 (comment)). (this behavior is already present)

This case requires custom handling: instead of creating role and
role_binding we need to create clusterrole and clusterrolebinding with
the required permissions. (these are the changes)
```
