### PR TITLE
Docs: add info on other restricted volumeMounts

### DIFF
--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -120,8 +120,9 @@ jenkins:
         claimName: jenkins-backup
 
   # volumeMounts are mounts for Jenkins pod
-  # Note that attempting to overwrite default mount settings for Jenkins home directory will result in Operator error
-  # See https://jenkinsci.github.io/kubernetes-operator/docs/installation/#note-on-jenkins-home-volume
+  # Note that attempting to overwrite default mount settings for restricted,
+  # non-configurable volumeMounts will result in Operator error
+  # See https://jenkinsci.github.io/kubernetes-operator/docs/installation/#note-on-restricted-jenkins-controller-pod-volumemounts for details
   volumeMounts: []
 
   # defines authorization strategy of the operator for the Jenkins API

--- a/website/content/en/docs/Getting Started/latest/schema.md
+++ b/website/content/en/docs/Getting Started/latest/schema.md
@@ -661,7 +661,12 @@ Values defined by an Env with a duplicate key will take precedence.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Pod volumes to mount into the container&rsquo;s filesystem. More info: https://jenkinsci.github.io/kubernetes-operator/docs/installation/#note-on-restricted-jenkins-controller-pod-volumemounts</p>
+<p>
+Pod volumes to mount into the container&rsquo;s filesystem. More info:
+<a href="https://jenkinsci.github.io/kubernetes-operator/docs/installation/#note-on-restricted-jenkins-controller-pod-volumemounts">
+https://jenkinsci.github.io/kubernetes-operator/docs/installation/#note-on-restricted-jenkins-controller-pod-volumemounts
+</a>
+</p>
 </td>
 </tr>
 <tr>

--- a/website/content/en/docs/Getting Started/latest/schema.md
+++ b/website/content/en/docs/Getting Started/latest/schema.md
@@ -661,7 +661,7 @@ Values defined by an Env with a duplicate key will take precedence.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Pod volumes to mount into the container&rsquo;s filesystem.</p>
+<p>Pod volumes to mount into the container&rsquo;s filesystem. More info: https://jenkinsci.github.io/kubernetes-operator/docs/installation/#note-on-restricted-jenkins-controller-pod-volumemounts</p>
 </td>
 </tr>
 <tr>

--- a/website/content/en/docs/Installation/_index.md
+++ b/website/content/en/docs/Installation/_index.md
@@ -889,7 +889,7 @@ One of the key points of this design is maintaining an immutable state of Jenkin
 
 One of the prerequisites of this is an ephemeral Jenkins home directory. To achieve that, Operator mounts emptyDir Volume
 (jenkins-home) as Jenkins home directory.
-It is not possible to overwrite volumeMount and specify any other Volume forJenkins home directory,
+It is not possible to overwrite volumeMount and specify any other Volume for Jenkins home directory,
 as attempting to do so will result in Operator error.
 
 jenkins-home is not the only Jenkins controller pod volumeMount that is non-configurable and managed by Operator,

--- a/website/content/en/docs/Installation/_index.md
+++ b/website/content/en/docs/Installation/_index.md
@@ -883,7 +883,19 @@ If you wish to use the newest, not yet released version of the Operator, you can
 
 You can find nightly built images by heading to [virtuslab/jenkins-operator](https://hub.docker.com/r/virtuslab/jenkins-operator) Docker Hub repository and looking for images with tag in the form of "{git-hash}", {git-hash} being the hash of master branch commit that you want to use snapshot of.
 
-## Note on Jenkins home Volume
-Current design of the Operator puts an emphasis on creating a full GitOps flow of work for Jenkins users. One of the key points of this design is maintaining an immutable state of Jenkins. 
+## Note on restricted Jenkins controller pod volumeMounts
+Current design of the Operator puts an emphasis on creating a full GitOps flow of work for Jenkins users.
+One of the key points of this design is maintaining an immutable state of Jenkins. 
 
-One of the prerequisites of this is an ephemeral Jenkins home directory. To achieve that, Operator mounts emptyDir Volume as Jenkins home directory. It is not possible to overwrite volumeMount and specify any other Volume for Jenkins home directory, as attempting to do so will result in Operator error.
+One of the prerequisites of this is an ephemeral Jenkins home directory. To achieve that, Operator mounts emptyDir Volume
+(jenkins-home) as Jenkins home directory.
+It is not possible to overwrite volumeMount and specify any other Volume forJenkins home directory,
+as attempting to do so will result in Operator error.
+
+jenkins-home is not the only Jenkins controller pod volumeMount that is non-configurable and managed by Operator,
+below is the full list of those volumeMounts:
+
+* jenkins-home
+* scripts
+* init-configuration
+* operator-credentials


### PR DESCRIPTION
# Changes
* add information on other restricted volumeMounts besides jenkins-home to docs
* link there from schema
* link there from Helm chart default values.yaml