### PR TITLE
Helm chart: fix creating role and rb when jenkins namespace is empty

### DIFF
--- a/chart/jenkins-operator/templates/role.yaml
+++ b/chart/jenkins-operator/templates/role.yaml
@@ -1,4 +1,15 @@
-{{ template "jenkins-operator.role" .Release.Namespace }}
-{{ if ne .Release.Namespace .Values.jenkins.namespace }}
-{{ template "jenkins-operator.role" .Values.jenkins.namespace }}
+{{ if eq .Values.jenkins.namespace "" }}
+{{- /*
+# This is a special case when .Values.jenkins.namespace is equal to empty
+# string which leads to WATCH_NAMESPACE env of jenkins-operator to be set to
+# empty string and leads to operator actually watching all namespaces. In this
+# case we need to create clusterrole and clusterrolebinding instead of role and
+# rolebinding
+*/ -}}
+  {{- template "jenkins-operator.role" .Values.jenkins.namespace }}
+{{ else }}
+  {{- template "jenkins-operator.role" .Release.Namespace }}
+  {{- if ne .Release.Namespace .Values.jenkins.namespace -}}
+    {{- template "jenkins-operator.role" .Values.jenkins.namespace }}
+  {{- end }}
 {{ end }}

--- a/chart/jenkins-operator/templates/role_binding.yaml
+++ b/chart/jenkins-operator/templates/role_binding.yaml
@@ -1,3 +1,25 @@
+{{ if eq .Values.jenkins.namespace "" }}
+{{- /*
+# This is a special case when .Values.jenkins.namespace is equal to empty
+# string which leads to WATCH_NAMESPACE env of jenkins-operator to be set to
+# empty string and leads to operator actually watching all namespaces. In this
+# case we need to create clusterrole and clusterrolebinding instead of role and
+# rolebinding
+*/ -}}
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: jenkins-operator
+subjects:
+  - kind: ServiceAccount
+    name: jenkins-operator
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: jenkins-operator
+  apiGroup: rbac.authorization.k8s.io
+{{ else }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -12,28 +34,7 @@ roleRef:
   kind: Role
   name: jenkins-operator
   apiGroup: rbac.authorization.k8s.io
-{{ if eq .Values.jenkins.namespace "" }}
-{{- /*
-# This is a special case when .Values.jenkins.namespace is equal to empty
-# string which leads to WATCH_NAMESPACE env of jenkins-operator to be set to
-# empty string and leads to operator actually watching all namespaces. In this
-# case we need to create clusterrole and clusterrolebinding instead of role and
-# rolebinding
-*/}}
----
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: jenkins-operator
-subjects:
-  - kind: ServiceAccount
-    name: jenkins-operator
-    namespace: {{ .Release.Namespace }}
-roleRef:
-  kind: ClusterRole
-  name: jenkins-operator
-  apiGroup: rbac.authorization.k8s.io
-{{ else if ne .Release.Namespace .Values.jenkins.namespace }}
+{{ if ne .Release.Namespace .Values.jenkins.namespace }}
 ---
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -48,4 +49,5 @@ roleRef:
   kind: Role
   name: jenkins-operator
   apiGroup: rbac.authorization.k8s.io
+{{ end }}
 {{ end }}


### PR DESCRIPTION
# Changes
Modified Jenkins Operator Role and RoleBinding templates to create Role and RoleBinding in neither Jenkins nor Operator namespace if Jenkins namespace is an empty string (because in this case, ClusterRole and ClusterRoleBinding are created).