### PR TITLE
Add step to update 'last modified' date in docs autogen workflow

### DIFF
--- a/.github/workflows/auto-gen-docs.yaml
+++ b/.github/workflows/auto-gen-docs.yaml
@@ -55,6 +55,12 @@ jobs:
           sudo npm install -D --save postcss-cli
           cd ../
 
+      - name: Update last modified date in modified docs
+        if: env.IS_CHANGED == 'true'
+        run: |
+          git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -E "^website*" \
+          | sed -e 's/\(.*\)/"\1"/' | xargs sed -i "/date:/c\date: $(date +'%Y-%m-%d')"
+
       # Runs makefile goal - checks changes to /website folder and generates docs
       - name: Run Makefile goal
         if: env.IS_CHANGED == 'true'


### PR DESCRIPTION
# Changes
Adds a step to workflow for autogenerating docs that updates 'last modified' date in the markdowns that were modified in a commit that triggered the workflow. 

# Submitter Checklist
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)