### PR TITLE
Fix Helm package URL in Makefile & Index entry for 0.5.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ helm-release-latest: helm
 	mv chart/jenkins-operator/*.tgz /tmp/jenkins-operator-charts
 	cd chart && ../bin/helm package jenkins-operator
 	mv chart/jenkins-operator-*.tgz chart/jenkins-operator/
-	bin/helm repo index chart/ --url https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/chart/jenkins-operator/ --merge chart/index.yaml
+	bin/helm repo index chart/ --url https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/chart/ --merge chart/index.yaml
 	mv /tmp/jenkins-operator-charts/*.tgz chart/jenkins-operator/
 
 # Download and build hugo extended locally if necessary

--- a/chart/index.yaml
+++ b/chart/index.yaml
@@ -9,7 +9,7 @@ entries:
     icon: https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/assets/jenkins-operator-icon.png
     name: jenkins-operator
     urls:
-    - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/chart/jenkins-operator/jenkins-operator/jenkins-operator-0.5.3.tgz
+    - https://raw.githubusercontent.com/jenkinsci/kubernetes-operator/master/chart/jenkins-operator/jenkins-operator-0.5.3.tgz
     version: 0.5.3
   - apiVersion: v2
     appVersion: 0.6.0


### PR DESCRIPTION
# Changes
* Fixes users not being able to install latest version of Operator via Helm chart (https://community.jenkins.io/t/failed-to-install-jenkins-operator-using-helm/306/2)
* Fixes Makefile goal for releasing Helm chart to avoid this issue coming up in the future

# Submitter Checklist
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)