### PR TITLE
Add HostAliases to schema

### DIFF
--- a/api/v1alpha2/jenkins_types.go
+++ b/api/v1alpha2/jenkins_types.go
@@ -368,6 +368,10 @@ type JenkinsMaster struct {
 	// PriorityClassName for Jenkins master pod
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// HostAliases for Jenkins master pod and SeedJob agent
+	// +optional
+	HostAliases []corev1.HostAlias `json:"hostAliases,omitempty"`
 }
 
 // Service defines Kubernetes service attributes

--- a/pkg/configuration/base/resources/deployment.go
+++ b/pkg/configuration/base/resources/deployment.go
@@ -37,7 +37,7 @@ func NewJenkinsDeployment(objectMeta metav1.ObjectMeta, jenkins *v1alpha2.Jenkin
 					ImagePullSecrets:   jenkins.Spec.Master.ImagePullSecrets,
 					Tolerations:        jenkins.Spec.Master.Tolerations,
 					PriorityClassName:  jenkins.Spec.Master.PriorityClassName,
-					HostAliases: 		jenkins.Spec.Master.HostAliases,
+					HostAliases: 	    jenkins.Spec.Master.HostAliases,
 				},
 			},
 			Selector: selector,

--- a/pkg/configuration/base/resources/deployment.go
+++ b/pkg/configuration/base/resources/deployment.go
@@ -37,6 +37,7 @@ func NewJenkinsDeployment(objectMeta metav1.ObjectMeta, jenkins *v1alpha2.Jenkin
 					ImagePullSecrets:   jenkins.Spec.Master.ImagePullSecrets,
 					Tolerations:        jenkins.Spec.Master.Tolerations,
 					PriorityClassName:  jenkins.Spec.Master.PriorityClassName,
+					HostAliases: 		jenkins.Spec.Master.HostAliases,
 				},
 			},
 			Selector: selector,

--- a/pkg/configuration/base/resources/pod.go
+++ b/pkg/configuration/base/resources/pod.go
@@ -380,6 +380,7 @@ func NewJenkinsMasterPod(objectMeta metav1.ObjectMeta, jenkins *v1alpha2.Jenkins
 			ImagePullSecrets:   jenkins.Spec.Master.ImagePullSecrets,
 			Tolerations:        jenkins.Spec.Master.Tolerations,
 			PriorityClassName:  jenkins.Spec.Master.PriorityClassName,
+			HostAliases: 		jenkins.Spec.Master.HostAliases,
 		},
 	}
 }

--- a/pkg/configuration/base/resources/pod.go
+++ b/pkg/configuration/base/resources/pod.go
@@ -380,7 +380,7 @@ func NewJenkinsMasterPod(objectMeta metav1.ObjectMeta, jenkins *v1alpha2.Jenkins
 			ImagePullSecrets:   jenkins.Spec.Master.ImagePullSecrets,
 			Tolerations:        jenkins.Spec.Master.Tolerations,
 			PriorityClassName:  jenkins.Spec.Master.PriorityClassName,
-			HostAliases: 		jenkins.Spec.Master.HostAliases,
+			HostAliases: 	    jenkins.Spec.Master.HostAliases,
 		},
 	}
 }

--- a/pkg/configuration/user/seedjobs/seedjobs.go
+++ b/pkg/configuration/user/seedjobs/seedjobs.go
@@ -435,6 +435,7 @@ func agentDeployment(jenkins *v1alpha2.Jenkins, namespace string, agentName stri
 					NodeSelector:     jenkins.Spec.Master.NodeSelector,
 					Tolerations:      jenkins.Spec.Master.Tolerations,
 					ImagePullSecrets: jenkins.Spec.Master.ImagePullSecrets,
+					HostAliases:      jenkins.Spec.Master.HostAliases,
 					Containers: []corev1.Container{
 						{
 							Name:  "jnlp",


### PR DESCRIPTION
Add HostAliases to schema and propagate them to pods so the user can add entries to /etc/hosts