### PR TITLE
#674 move imagePullSecrets in template

### DIFF
--- a/chart/jenkins-operator/templates/jenkins.yaml
+++ b/chart/jenkins-operator/templates/jenkins.yaml
@@ -106,9 +106,6 @@ spec:
       - name:  jenkins-master
         image: {{ .Values.jenkins.image }}
         imagePullPolicy: {{ .Values.jenkins.imagePullPolicy }}
-        {{- with .Values.jenkins.imagePullSecrets }}
-        imagePullSecrets: {{ toYaml . | nindent 10 }}
-        {{- end }}
         {{- with .Values.jenkins.livenessProbe }}
         livenessProbe: {{ toYaml . | nindent 10 }}
         {{- end }}
@@ -140,6 +137,9 @@ spec:
       {{- end }}
     {{- with .Values.jenkins.volumes }}
     volumes: {{- toYaml . | nindent 4 }}
+    {{- end }}
+    {{- with .Values.jenkins.imagePullSecrets }}
+    imagePullSecrets: {{ toYaml . | nindent 10 }}
     {{- end }}
     {{- with .Values.jenkins.securityContext}}
     securityContext:


### PR DESCRIPTION
fix https://github.com/jenkinsci/kubernetes-operator/issues/674

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

move imagePullSecrets in template to the place expected by CRD

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).
