### PR TITLE
Chore: fix Helm chart release workflow breaking

### DIFF
--- a/.github/workflows/release-helm-chart.yaml
+++ b/.github/workflows/release-helm-chart.yaml
@@ -21,10 +21,10 @@ jobs:
 
       - name: Deploy Helm chart
         run: |
-          sed -i "/version:/c\version: ${{ github.event.inputs.chartVersion }}" chart/jenkins-operator/Chart.yaml
+          sed -i '0,/version:.*/s//version: ${{ github.event.inputs.chartVersion }}/' chart/jenkins-operator/Chart.yaml
 
           if [ ${{ github.event.inputs.appVersion }} ] ; then
-            sed -i "/appVersion:/c\appVersion: \"${{ github.event.inputs.appVersion }}\"" chart/jenkins-operator/Chart.yaml
+            sed -i '/appVersion:.*/s//appVersion: "${{ github.event.inputs.appVersion }}"/' chart/jenkins-operator/Chart.yaml
           fi
 
           make helm-release-latest


### PR DESCRIPTION
Workflow was failing because it didn't account for "version:" pattern appearing more than once in the Chart.yaml file.

# Changes
* modified sed usage to account for dependencies section now present in Chart.yaml
* now sed only looks for the first line with "version:" 