### PR TITLE
#685 Do not strip leading whitespace from priorityClassName in helm template

### DIFF
--- a/chart/jenkins-operator/templates/jenkins.yaml
+++ b/chart/jenkins-operator/templates/jenkins.yaml
@@ -99,7 +99,7 @@ spec:
     plugins: {{ toYaml . | nindent 4 }}
     {{- end }}
     {{- if .Values.jenkins.priorityClassName }}
-    priorityClassName: {{- .Values.jenkins.priorityClassName }}
+    priorityClassName: {{ .Values.jenkins.priorityClassName }}
     {{- end }}
     disableCSRFProtection: {{ .Values.jenkins.disableCSRFProtection }}
     containers:


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Do not strip leading whitespace from `priorityClassName` in helm template

fixes #685

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

- Bug fixes
Allow specifying jenkins `priorityClassName` within helm chart
