### PR TITLE
Fixes #687 - Enable customization of master Jenkins service account via default Helm template

### DIFF
--- a/chart/jenkins-operator/templates/jenkins.yaml
+++ b/chart/jenkins-operator/templates/jenkins.yaml
@@ -85,6 +85,9 @@ spec:
   {{- with .Values.jenkins.notifications }}
   notifications: {{ toYaml . | nindent 4 }}
   {{- end }}
+  {{- with .Values.jenkins.serviceAccount }}
+  serviceAccount: {{ toYaml . | nindent 4 }}
+  {{- end }}
   master:
     {{- with .Values.jenkins.labels }}
     labels: {{ toYaml . | nindent 6 }}

--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -59,6 +59,11 @@ jenkins:
   # See https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/notifications/ for more info
   notifications: []
 
+  # Enables customization of the Service Account attached to the master Jenkins instance via annotations
+  # https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/schema/#github.com/jenkinsci/kubernetes-operator/api/v1alpha2.ServiceAccount
+  serviceAccount:
+    annotations: {}
+
   # basePlugins are plugins installed and required by the operator
   # Shouldn't contain plugins defined by user
   # You can change their versions here


### PR DESCRIPTION
This is necessary in order to be able to provide the annotations attached to the
service account associated with the Jenkins master instance.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

I have made the small changes necessary in order to enable adapting the `ServiceAccount` used by the master Jenkins which is provisioned with the default Helm chart.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes tests (if functionality changed/added) => No functionality added
- [X] Includes docs (if user facing) => already available and is referenced 
- [ ] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages) => To be determined by reviewer.

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

