### PR TITLE
Build multi-arch images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,8 @@ ARG GO_VERSION
 # Build the manager binary
 FROM golang:$GO_VERSION as builder
 ARG CTIMEVAR
+ARG TARGETOS
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -21,7 +23,7 @@ COPY version/ version/
 COPY main.go main.go
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -ldflags "-w $CTIMEVAR" -o manager main.go
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH GO111MODULE=on go build -ldflags "-w $CTIMEVAR" -o manager main.go
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details

--- a/api/v1alpha2/jenkins_types.go
+++ b/api/v1alpha2/jenkins_types.go
@@ -346,20 +346,20 @@ type JenkinsMaster struct {
 	// BasePlugins contains plugins required by operator
 	// +optional
 	// Defaults to :
-	// - name: kubernetes
-	// version: "1.30.11"
-	// - name: workflow-job
-	// version: "1145.v7f2433caa07f"
-	// - name: workflow-aggregator
-	// version: "2.6"
+	// - name: configuration-as-code
+	// version: "1346.ve8cfa_3473c94"
 	// - name: git
-	// version: "4.10.0"
+	// version: "4.10.3"
 	// - name: job-dsl
 	// version: "1.78.1"
-	// - name: configuration-as-code
-	// version: "1.55"
+	// - name: kubernetes
+	// version: "1.31.3"
 	// - name: kubernetes-credentials-provider
 	// version: "0.20"
+	// - name: workflow-aggregator
+	// version: "2.6"
+	// - name: workflow-job
+	// version: "1145.v7f2433caa07f"
 	BasePlugins []Plugin `json:"basePlugins,omitempty"`
 
 	// Plugins contains plugins required by user

--- a/chart/jenkins-operator/crds/jenkins-crd.yaml
+++ b/chart/jenkins-operator/crds/jenkins-crd.yaml
@@ -157,10 +157,10 @@ spec:
                     type: object
                   basePlugins:
                     description: 'BasePlugins contains plugins required by operator
-                      Defaults to : - name: kubernetes version: "1.30.11" - name:
+                      Defaults to : - name: kubernetes version: "1.31.3" - name:
                       workflow-job version: "1145.v7f2433caa07f" - name: workflow-aggregator version:
-                      "2.6" - name: git version: "4.10.0" - name: job-dsl version:
-                      "1.78.1" - name: configuration-as-code version: "1.55" - name:
+                      "2.6" - name: git version: "4.10.3" - name: job-dsl version:
+                      "1.78.1" - name: configuration-as-code version: "1346.ve8cfa_3473c94" - name:
                       kubernetes-credentials-provider version: "0.20"'
                     items:
                       description: Plugin defines Jenkins plugin.

--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -118,7 +118,7 @@ jenkins:
       cpu: 1000m
       memory: 3Gi
     requests:
-      cpu: 1
+      cpu: 250m
       memory: 500Mi
 
   # volumes used by Jenkins

--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -30,7 +30,7 @@ jenkins:
   # image is the name (and tag) of the Jenkins instance
   # Default: jenkins/jenkins:lts
   # It's recommended to use LTS (tag: "lts") version
-  image: jenkins/jenkins:2.319.1-lts-alpine
+  image: jenkins/jenkins:2.319.3-lts
 
   # env contains jenkins container environment variables
   env: []
@@ -72,20 +72,20 @@ jenkins:
   # Example:
   #
   # basePlugins:
-  # - name: kubernetes
-  #   version: 1.30.11
-  # - name: workflow-job
-  #   version: "1145.v7f2433caa07f"
-  # - name: workflow-aggregator
-  #   version: "2.6"
+  # - name: configuration-as-code
+  #   version: "1346.ve8cfa_3473c94"
   # - name: git
-  #   version: 4.10.0
+  #   version: 4.10.3
   # - name: job-dsl
   #   version: "1.78.1"
-  # - name: configuration-as-code
-  #   version: "1.55"
+  # - name: kubernetes
+  #   version: 1.31.3
   # - name: kubernetes-credentials-provider
   #   version: 0.20
+  # - name: workflow-aggregator
+  #   version: "2.6"
+  # - name: workflow-job
+  #   version: "1145.v7f2433caa07f"
   basePlugins: []
 
   # plugins are plugins required by the user

--- a/config/crd/bases/jenkins.io_jenkins.yaml
+++ b/config/crd/bases/jenkins.io_jenkins.yaml
@@ -157,10 +157,10 @@ spec:
                     type: object
                   basePlugins:
                     description: 'BasePlugins contains plugins required by operator
-                      Defaults to : - name: kubernetes version: "1.30.11" - name:
+                      Defaults to : - name: kubernetes version: "1.31.3" - name:
                       workflow-job version: "1145.v7f2433caa07f" - name: workflow-aggregator version:
-                      "2.6" - name: git version: "4.10.0" - name: job-dsl version:
-                      "1.78.1" - name: configuration-as-code version: "1.55" - name:
+                      "2.6" - name: git version: "4.10.3" - name: job-dsl version:
+                      "1.78.1" - name: configuration-as-code version: "1346.ve8cfa_3473c94" - name:
                       kubernetes-credentials-provider version: "0.20"'
                     items:
                       description: Plugin defines Jenkins plugin.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -8,7 +8,7 @@ const (
 	// SeedJobSuffix is a suffix added for all seed jobs
 	SeedJobSuffix = "job-dsl-seed"
 	// DefaultJenkinsMasterImage is the default Jenkins master docker image
-	DefaultJenkinsMasterImage = "jenkins/jenkins:2.303.2-lts-alpine"
+	DefaultJenkinsMasterImage = "jenkins/jenkins:2.319.3-lts"
 	// DefaultHTTPPortInt32 is the default Jenkins HTTP port
 	DefaultHTTPPortInt32 = int32(8080)
 	// DefaultSlavePortInt32 is the default Jenkins port for slaves

--- a/pkg/plugins/base_plugins.go
+++ b/pkg/plugins/base_plugins.go
@@ -1,24 +1,24 @@
 package plugins
 
 const (
-	configurationAsCodePlugin           = "configuration-as-code:1.55"
-	gitPlugin                           = "git:4.10.0"
+	configurationAsCodePlugin           = "configuration-as-code:1346.ve8cfa_3473c94"
+	gitPlugin                           = "git:4.10.3"
 	jobDslPlugin                        = "job-dsl:1.78.1"
+	kubernetesPlugin                    = "kubernetes:1.31.3"
 	kubernetesCredentialsProviderPlugin = "kubernetes-credentials-provider:0.20"
-	kubernetesPlugin                    = "kubernetes:1.30.11"
 	workflowAggregatorPlugin            = "workflow-aggregator:2.6"
 	workflowJobPlugin                   = "workflow-job:1145.v7f2433caa07f"
 )
 
 // basePluginsList contains plugins to install by operator.
 var basePluginsList = []Plugin{
-	Must(New(kubernetesPlugin)),
-	Must(New(workflowJobPlugin)),
-	Must(New(workflowAggregatorPlugin)),
+	Must(New(configurationAsCodePlugin)),
 	Must(New(gitPlugin)),
 	Must(New(jobDslPlugin)),
-	Must(New(configurationAsCodePlugin)),
+	Must(New(kubernetesPlugin)),
 	Must(New(kubernetesCredentialsProviderPlugin)),
+	Must(New(workflowJobPlugin)),
+	Must(New(workflowAggregatorPlugin)),
 }
 
 // BasePlugins returns list of plugins to install by operator.

--- a/test/e2e/configuration_test.go
+++ b/test/e2e/configuration_test.go
@@ -23,6 +23,16 @@ import (
 
 const e2e = "e2e"
 
+var expectedBasePluginsList = []plugins.Plugin{
+	plugins.Must(plugins.New("configuration-as-code:1346.ve8cfa_3473c94")),
+	plugins.Must(plugins.New("git:4.10.3")),
+	plugins.Must(plugins.New("kubernetes:1.31.3")),
+	plugins.Must(plugins.New("kubernetes-credentials-provider:0.20")),
+	plugins.Must(plugins.New("job-dsl:1.78.1")),
+	plugins.Must(plugins.New("workflow-aggregator:2.6")),
+	plugins.Must(plugins.New("workflow-job:1145.v7f2433caa07f")),
+}
+
 func createUserConfigurationSecret(namespace string, stringData map[string]string) {
 	By("creating user configuration secret")
 
@@ -179,7 +189,7 @@ func verifyPlugins(jenkinsClient jenkinsclient.Jenkins, jenkins *v1alpha2.Jenkin
 	installedPlugins, err := jenkinsClient.GetPlugins(1)
 	Expect(err).NotTo(HaveOccurred())
 
-	for _, basePlugin := range plugins.BasePlugins() {
+	for _, basePlugin := range expectedBasePluginsList {
 		if found, ok := isPluginValid(installedPlugins, basePlugin); !ok {
 			Fail(fmt.Sprintf("Invalid plugin '%s', actual '%+v'", basePlugin, found))
 		}

--- a/test/e2e/jenkins_test.go
+++ b/test/e2e/jenkins_test.go
@@ -104,7 +104,7 @@ func createJenkinsCRSafeRestart(name, namespace string, seedJob *[]v1alpha2.Seed
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceCPU:    resource.MustParse("250m"),
 								corev1.ResourceMemory: resource.MustParse("500Mi"),
 							},
 							Limits: corev1.ResourceList{

--- a/test/e2e/restorebackup_test.go
+++ b/test/e2e/restorebackup_test.go
@@ -146,7 +146,7 @@ func createJenkinsWithBackupAndRestoreConfigured(name, namespace string) *v1alph
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceCPU:    resource.MustParse("250m"),
 								corev1.ResourceMemory: resource.MustParse("500Mi"),
 							},
 							Limits: corev1.ResourceList{

--- a/test/e2e/test_utility.go
+++ b/test/e2e/test_utility.go
@@ -126,7 +126,7 @@ func RenderJenkinsCR(name, namespace string, seedJob *[]v1alpha2.SeedJob, groovy
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("1"),
+								corev1.ResourceCPU:    resource.MustParse("250m"),
 								corev1.ResourceMemory: resource.MustParse("500Mi"),
 							},
 							Limits: corev1.ResourceList{

--- a/test/e2e/test_utility.go
+++ b/test/e2e/test_utility.go
@@ -21,7 +21,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
 
-const JenkinsTestImage = "jenkins/jenkins:2.319.1-lts"
+const JenkinsTestImage = "jenkins/jenkins:2.319.3-lts"
 
 var (
 	Cfg       *rest.Config

--- a/test/helm/helm_test.go
+++ b/test/helm/helm_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Jenkins Controller", func() {
 
 			cmd := exec.Command("../../bin/helm", "upgrade", "jenkins", "../../chart/jenkins-operator", "--namespace", namespace.Name, "--debug",
 				"--set-string", fmt.Sprintf("jenkins.namespace=%s", namespace.Name),
-				"--set-string", fmt.Sprintf("jenkins.image=%s", "jenkins/jenkins:2.303.2-lts"),
+				"--set-string", fmt.Sprintf("jenkins.image=%s", "jenkins/jenkins:2.319.3-lts"),
 				"--set-string", fmt.Sprintf("operator.image=%s", *imageName), "--install")
 			output, err := cmd.CombinedOutput()
 			Expect(err).NotTo(HaveOccurred(), string(output))


### PR DESCRIPTION
# Changes

Changed Dockerfile & Makefile to build a multi-platform (amd64 and arm64) image of jenkins-operator.
Using `TARGETOS` and `TARGETARCH` in the builder and leverage `docker build build` command in the Makefile.

:boom: Breaking changes :boom:
It is required to run `docker buildx create --use` before being able to create & push the image to registry.
Currently podman does not support buildx features, this changes requires `CONTAINER_RUNTIME_COMMAND=docker`.

🧪 Unit tests changes 🧪 
Fixing unit tests with the following changes:
* reduce Jenkins CPU requirements from `1` to `250m`
* upgrade Jenkins image to `jenkins/jenkins:2.319.3-lts`

# Release Notes

```
Support multi-arch (amd64 and arm64) container image.

Upgrade base plugins to following versions:
* configuration-as-code: v1346.ve8cfa_3473c94
* git: 4.10.3
* job-dsl: 1.78.1
* kubernetes: 1.31.3
* workflow-job: 1145.v7f2433caa07f
```
