### PR TITLE
Receive plugins' versions with underscores.

### DIFF
--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -24,7 +24,7 @@ var (
 	// NamePattern is the plugin name regex pattern
 	NamePattern = regexp.MustCompile(`^[0-9a-zA-Z-_]+$`)
 	// VersionPattern is the plugin version regex pattern
-	VersionPattern = regexp.MustCompile(`^[0-9a-zA-Z+\\.-]+$`)
+	VersionPattern = regexp.MustCompile(`^[0-9a-zA-Z+\\.-_]+$`)
 	// DownloadURLPattern is the plugin download url regex pattern
 	DownloadURLPattern = regexp.MustCompile(`https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)`)
 )

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -22,9 +22,9 @@ func (p Plugin) String() string {
 
 var (
 	// NamePattern is the plugin name regex pattern
-	NamePattern = regexp.MustCompile(`^[0-9a-zA-Z-_]+$`)
+	NamePattern = regexp.MustCompile(`^[0-9a-zA-Z\-_]+$`)
 	// VersionPattern is the plugin version regex pattern
-	VersionPattern = regexp.MustCompile(`^[0-9a-zA-Z+\\.-_]+$`)
+	VersionPattern = regexp.MustCompile(`^[0-9a-zA-Z\-_+\\.]+$`)
 	// DownloadURLPattern is the plugin download url regex pattern
 	DownloadURLPattern = regexp.MustCompile(`https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)`)
 )

--- a/pkg/plugins/plugin_test.go
+++ b/pkg/plugins/plugin_test.go
@@ -36,6 +36,10 @@ func TestValidatePlugin(t *testing.T) {
 		got := validatePlugin(validPluginName, "3.1.20180605-140134.c2e96c4", "")
 		assert.NoError(t, got)
 	})
+	t.Run("version 1074.v60e6c29b_b_44b_", func(t *testing.T) {
+		got := validatePlugin(validPluginName, "1074.v60e6c29b_b_44b_", "")
+		assert.NoError(t, got)
+	})
 	t.Run("invalid version !", func(t *testing.T) {
 		got := validatePlugin(validPluginName, "0.5.1!", "")
 		assert.Error(t, got)


### PR DESCRIPTION
New jenkins plugin versions have underscores in them (example: https://plugins.jenkins.io/credentials/). The operator refuses configuration for such plug-ins as they do not match the existing regex.

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
