### PR TITLE
Fix release pipeline

### DIFF
--- a/.github/workflows/deploy-nightly.yaml
+++ b/.github/workflows/deploy-nightly.yaml
@@ -65,11 +65,11 @@ jobs:
           eval $(bin/minikube docker-env)
           make helm-e2e E2E_TEST_ARGS='-ginkgo.v'
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+#      - name: Login to DockerHub
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+#          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Release Container Runtime
         run: |

--- a/.github/workflows/deploy-nightly.yaml
+++ b/.github/workflows/deploy-nightly.yaml
@@ -38,8 +38,8 @@ jobs:
       - name: Ensure Golang runtime dependencies
         run: make go-dependencies
 
-      - name: Verify code formatting
-        run: make verify
+#      - name: Verify code formatting
+#        run: make verify
 
       - name: Prepare environment for e2e
         if: ${{ github.event.inputs.skipTests != 'true' }}

--- a/.github/workflows/deploy-nightly.yaml
+++ b/.github/workflows/deploy-nightly.yaml
@@ -38,8 +38,8 @@ jobs:
       - name: Ensure Golang runtime dependencies
         run: make go-dependencies
 
-#      - name: Verify code formatting
-#        run: make verify
+      - name: Verify code formatting
+        run: make verify
 
       - name: Prepare environment for e2e
         if: ${{ github.event.inputs.skipTests != 'true' }}
@@ -65,11 +65,11 @@ jobs:
           eval $(bin/minikube docker-env)
           make helm-e2e E2E_TEST_ARGS='-ginkgo.v'
 
-#      - name: Login to DockerHub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-#          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Release Container Runtime
         run: |

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,6 @@ container-runtime-login: ## Log in into the Docker repository
 container-runtime-build-%: ## Build the container
 	@echo "+ $@"
 	$(CONTAINER_RUNTIME_COMMAND) buildx build \
-		--driver=docker-container
 		--output=type=docker --platform linux/$* \
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg CTIMEVAR="$(CTIMEVAR)" \
@@ -229,6 +228,7 @@ container-runtime-images: ## List all local containers
 ## Parameter is version
 define container-runtime-push-command
 $(CONTAINER_RUNTIME_COMMAND) buildx build \
+	--driver=docker-container
 	--output=type=registry --platform linux/amd64,linux/arm64 \
 	--build-arg GO_VERSION=$(GO_VERSION) \
 	--build-arg CTIMEVAR="$(CTIMEVAR)" \

--- a/Makefile
+++ b/Makefile
@@ -211,6 +211,7 @@ container-runtime-login: ## Log in into the Docker repository
 container-runtime-build-%: ## Build the container
 	@echo "+ $@"
 	$(CONTAINER_RUNTIME_COMMAND) buildx build \
+		--driver=docker-container
 		--output=type=docker --platform linux/$* \
 		--build-arg GO_VERSION=$(GO_VERSION) \
 		--build-arg CTIMEVAR="$(CTIMEVAR)" \

--- a/Makefile
+++ b/Makefile
@@ -228,6 +228,7 @@ container-runtime-images: ## List all local containers
 define buildx-create-command
 $(CONTAINER_RUNTIME_COMMAND) buildx create \
 	--driver=docker-container
+	--use
 endef
 
 ## Parameter is version

--- a/Makefile
+++ b/Makefile
@@ -225,10 +225,14 @@ container-runtime-images: ## List all local containers
 	@echo "+ $@"
 	$(CONTAINER_RUNTIME_COMMAND) images $(CONTAINER_RUNTIME_EXTRA_ARGS)
 
+define buildx-create-command
+$(CONTAINER_RUNTIME_COMMAND) buildx create \
+	--driver=docker-container
+endef
+
 ## Parameter is version
 define container-runtime-push-command
 $(CONTAINER_RUNTIME_COMMAND) buildx build \
-	--driver=docker-container
 	--output=type=registry --platform linux/amd64,linux/arm64 \
 	--build-arg GO_VERSION=$(GO_VERSION) \
 	--build-arg CTIMEVAR="$(CTIMEVAR)" \
@@ -239,21 +243,25 @@ endef
 .PHONY: container-runtime-push
 container-runtime-push: check-env deepcopy-gen ## Push the container
 	@echo "+ $@"
+	$(call buildx-create-command)
 	$(call container-runtime-push-command,$(BUILD_TAG))
 
 .PHONY: container-runtime-snapshot-push
 container-runtime-snapshot-push: check-env deepcopy-gen
 	@echo "+ $@"
+	$(call buildx-create-command)
 	$(call container-runtime-push-command,$(GITCOMMIT))
 
 .PHONY: container-runtime-release-version
 container-runtime-release-version: check-env deepcopy-gen ## Release image with version tag (in addition to build tag)
 	@echo "+ $@"
+	$(call buildx-create-command)
 	$(call container-runtime-push-command,$(VERSION_TAG))
 
 .PHONY: container-runtime-release-latest
 container-runtime-release-latest: check-env deepcopy-gen ## Release image with latest tags (in addition to build tag)
 	@echo "+ $@"
+	$(call buildx-create-command)
 	$(call container-runtime-push-command,$(LATEST_TAG))
 
 .PHONY: container-runtime-release

--- a/Makefile
+++ b/Makefile
@@ -227,7 +227,7 @@ container-runtime-images: ## List all local containers
 
 define buildx-create-command
 $(CONTAINER_RUNTIME_COMMAND) buildx create \
-	--driver=docker-container
+	--driver=docker-container \
 	--use
 endef
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Before building with buildx driver need to be specified through docker buildx create

I tested it on my fork and it seems ok, failing only because i didnt have the credentials to push:
https://github.com/bhubert/kubernetes-operator/runs/5214195607?check_suite_focus=true

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)
