### PR TITLE
Allow to specify seed agent image

### DIFF
--- a/api/v1alpha2/jenkins_types.go
+++ b/api/v1alpha2/jenkins_types.go
@@ -19,6 +19,7 @@ type JenkinsSpec struct {
 	SeedJobs []SeedJob `json:"seedJobs,omitempty"`
 
 	// SeedJobAgentImage defines the image the jnlp agent will use
+	// +optional
 	SeedJobAgentImage string `json:"seedJobAgentImage,omitempty"`
 
 	// ValidateSecurityWarnings enables or disables validating potential security warnings in Jenkins plugins via admission webhooks.

--- a/api/v1alpha2/jenkins_types.go
+++ b/api/v1alpha2/jenkins_types.go
@@ -18,6 +18,9 @@ type JenkinsSpec struct {
 	// +optional
 	SeedJobs []SeedJob `json:"seedJobs,omitempty"`
 
+	// SeedJobAgentImage defines the image the jnlp agent will use
+	SeedJobAgentImage string `json:"seedJobAgentImage,omitempty"`
+
 	// ValidateSecurityWarnings enables or disables validating potential security warnings in Jenkins plugins via admission webhooks.
 	//+optional
 	ValidateSecurityWarnings bool `json:"validateSecurityWarnings,omitempty"`

--- a/api/v1alpha2/jenkins_types.go
+++ b/api/v1alpha2/jenkins_types.go
@@ -18,7 +18,7 @@ type JenkinsSpec struct {
 	// +optional
 	SeedJobs []SeedJob `json:"seedJobs,omitempty"`
 
-	// SeedJobAgentImage defines the image the jnlp agent will use
+	// SeedJobAgentImage defines the image that will be used by the seed job agent. If not defined jenkins/inbound-agent:4.9-1 will be used.
 	// +optional
 	SeedJobAgentImage string `json:"seedJobAgentImage,omitempty"`
 

--- a/chart/jenkins-operator/crds/jenkins-crd.yaml
+++ b/chart/jenkins-operator/crds/jenkins-crd.yaml
@@ -3118,6 +3118,9 @@ spec:
                   - name
                   type: object
                 type: array
+              seedJobAgentImage:
+                  type: string
+                  description: 'SeedJobAgentImage defines the image that will be used by the seed job agent. If not defined jenkins/inbound-agent:4.9-1 will be used.'
               seedJobs:
                 description: 'SeedJobs defines list of Jenkins Seed Job configurations
                   More info: https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/configuration#configure-seed-jobs-and-pipelines'

--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -111,6 +111,9 @@ jenkins:
   #    repositoryUrl: https://github.com/jenkinsci/kubernetes-operator.git
   seedJobs: []
 
+  # SeedJobAgentImage defines the image that will be used by the seed job agent. If not defined jenkins/inbound-agent:4.9-1 will be used.
+  seedJobAgentImage: ""
+
   # Resource limit/request for Jenkins
   # See https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/ for details
   resources:

--- a/pkg/configuration/user/seedjobs/seedjobs.go
+++ b/pkg/configuration/user/seedjobs/seedjobs.go
@@ -43,6 +43,9 @@ const (
 	// AgentName is the name of seed job agent
 	AgentName = "seed-job-agent"
 
+	// DefaultAgentImage is the default image used for the seed-job agent
+	defaultAgentImage = "jenkins/inbound-agent:4.9-1"
+
 	creatingGroovyScriptName = "seed-job-groovy-script.groovy"
 
 	homeVolumeName = "home"
@@ -414,6 +417,11 @@ func agentDeployment(jenkins *v1alpha2.Jenkins, namespace string, agentName stri
 		return nil, err
 	}
 
+	agentImage := jenkins.Spec.SeedJobAgentImage
+	if jenkins.Spec.SeedJobAgentImage == "" {
+		agentImage = defaultAgentImage
+	}
+
 	suffix := ""
 	if prefix, ok := resources.GetJenkinsOpts(*jenkins)["prefix"]; ok {
 		suffix = prefix
@@ -443,7 +451,7 @@ func agentDeployment(jenkins *v1alpha2.Jenkins, namespace string, agentName stri
 					Containers: []corev1.Container{
 						{
 							Name:  "jnlp",
-							Image: "jenkins/inbound-agent:4.9-1",
+							Image: agentImage,
 							Env: []corev1.EnvVar{
 								{
 									Name: "JENKINS_TUNNEL",

--- a/pkg/configuration/user/seedjobs/seedjobs_test.go
+++ b/pkg/configuration/user/seedjobs/seedjobs_test.go
@@ -114,7 +114,6 @@ func TestEnsureSeedJobs(t *testing.T) {
 		err = fakeClient.Get(ctx, types.NamespacedName{Namespace: jenkins.Namespace, Name: agentDeploymentName(*jenkins, AgentName)}, &agentDeployment)
 		assert.NoError(t, err)
 		assert.Equal(t, "jenkins/inbound-agent:4.9-1", agentDeployment.Spec.Template.Spec.Containers[0].Image)
-
 	})
 
 	t.Run("delete agent deployment when no seed jobs", func(t *testing.T) {

--- a/pkg/configuration/user/seedjobs/seedjobs_test.go
+++ b/pkg/configuration/user/seedjobs/seedjobs_test.go
@@ -113,6 +113,8 @@ func TestEnsureSeedJobs(t *testing.T) {
 		var agentDeployment appsv1.Deployment
 		err = fakeClient.Get(ctx, types.NamespacedName{Namespace: jenkins.Namespace, Name: agentDeploymentName(*jenkins, AgentName)}, &agentDeployment)
 		assert.NoError(t, err)
+		assert.Equal(t, "jenkins/inbound-agent:4.9-1", agentDeployment.Spec.Template.Spec.Containers[0].Image)
+
 	})
 
 	t.Run("delete agent deployment when no seed jobs", func(t *testing.T) {


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

In my company we need to deploy a kubernetes cluster on ARM64 computers.
The image used by the seed agent is hardcoded with an AMD64 image which is a blocker for us.

This PR will allow users to specify the image they want for the seed agent.

If not specified the image previously hardcoded will be used.

Without this commit, previous PR about multi-arch is not really usefull since the seed agent wont follow the operator architecture.

resolves https://github.com/jenkinsci/kubernetes-operator/issues/700

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [x] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._

# Release Notes

```
API changes:
A new seedJobAgentImage can be used to specify the image the seed job agent will use


```
