### PR TITLE
Remove the validation of plugin version against a regex

### DIFF
--- a/pkg/configuration/base/validate_test.go
+++ b/pkg/configuration/base/validate_test.go
@@ -53,15 +53,6 @@ func TestValidatePlugins(t *testing.T) {
 
 		assert.Equal(t, got, []string{"invalid plugin name 'INVALID?:0.0.1', must follow pattern '" + plugins.NamePattern.String() + "'"})
 	})
-	t.Run("invalid user plugin version", func(t *testing.T) {
-		var requiredBasePlugins []plugins.Plugin
-		var basePlugins []v1alpha2.Plugin
-		userPlugins := []v1alpha2.Plugin{{Name: "simple-plugin", Version: "invalid!"}}
-
-		got := baseReconcileLoop.validatePlugins(requiredBasePlugins, basePlugins, userPlugins)
-
-		assert.Equal(t, got, []string{"invalid plugin version 'simple-plugin:invalid!', must follow pattern '" + plugins.VersionPattern.String() + "'"})
-	})
 	t.Run("valid base plugin", func(t *testing.T) {
 		var requiredBasePlugins []plugins.Plugin
 		basePlugins := []v1alpha2.Plugin{{Name: "simple-plugin", Version: "0.0.1"}}
@@ -79,15 +70,6 @@ func TestValidatePlugins(t *testing.T) {
 		got := baseReconcileLoop.validatePlugins(requiredBasePlugins, basePlugins, userPlugins)
 
 		assert.Equal(t, got, []string{"invalid plugin name 'INVALID?:0.0.1', must follow pattern '" + plugins.NamePattern.String() + "'"})
-	})
-	t.Run("invalid base plugin version", func(t *testing.T) {
-		var requiredBasePlugins []plugins.Plugin
-		basePlugins := []v1alpha2.Plugin{{Name: "simple-plugin", Version: "invalid!"}}
-		var userPlugins []v1alpha2.Plugin
-
-		got := baseReconcileLoop.validatePlugins(requiredBasePlugins, basePlugins, userPlugins)
-
-		assert.Equal(t, got, []string{"invalid plugin version 'simple-plugin:invalid!', must follow pattern '" + plugins.VersionPattern.String() + "'"})
 	})
 	t.Run("valid user and base plugin version", func(t *testing.T) {
 		var requiredBasePlugins []plugins.Plugin

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -23,8 +23,6 @@ func (p Plugin) String() string {
 var (
 	// NamePattern is the plugin name regex pattern
 	NamePattern = regexp.MustCompile(`^[0-9a-zA-Z\-_]+$`)
-	// VersionPattern is the plugin version regex pattern
-	VersionPattern = regexp.MustCompile(`^[0-9a-zA-Z\-_+\\.]+$`)
 	// DownloadURLPattern is the plugin download url regex pattern
 	DownloadURLPattern = regexp.MustCompile(`https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)`)
 )
@@ -64,9 +62,6 @@ func NewPlugin(name, version, downloadURL string) (*Plugin, error) {
 func validatePlugin(name, version, downloadURL string) error {
 	if ok := NamePattern.MatchString(name); !ok {
 		return errors.Errorf("invalid plugin name '%s:%s', must follow pattern '%s'", name, version, NamePattern.String())
-	}
-	if ok := VersionPattern.MatchString(version); !ok {
-		return errors.Errorf("invalid plugin version '%s:%s', must follow pattern '%s'", name, version, VersionPattern.String())
 	}
 	if len(downloadURL) > 0 {
 		if ok := DownloadURLPattern.MatchString(downloadURL); !ok {


### PR DESCRIPTION
The plugin versions have been validated against a regex. This has
led to an issue where the version formats which are allowed by
the Jenkins plugin repositories have apparently changed, which led to
failures to install newer versions of some plugins.

It was necessary to remove the plugin version validation in order to:
- Prevent unnecessary failures in Jenkins Operator when versions which
  are allowed by Jenkins plugin repositories change
- Enable more transparent error diagnosing, since if the version
  of plugin is not allowed, then Jenkins instance will fail to start
  with a clear message, stating that it was not able to find the plugin

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
This should solve the issue #711

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```

