### PR TITLE
Add seedJobAgentImage into CRD

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,11 @@
 run:
   deadline: 10m
+  skip-files:
+    - api/v1alpha2/zz_generated.deepcopy.go
 linters-settings:
   errcheck:
     check-blank: false
     ignore: fmt:.*,io/ioutil:^Read.*,Write
-
 linters:
   enable-all: true
   disable:

--- a/config/crd/bases/jenkins.io_jenkins.yaml
+++ b/config/crd/bases/jenkins.io_jenkins.yaml
@@ -3118,6 +3118,9 @@ spec:
                   - name
                   type: object
                 type: array
+              seedJobAgentImage:
+                type: string
+                description: SeedJobAgentImage defines the image that will be used by the seed job agent. If not defined jenkins/inbound-agent:4.9-1 will be used.
               seedJobs:
                 description: 'SeedJobs defines list of Jenkins Seed Job configurations
                   More info: https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/configuration#configure-seed-jobs-and-pipelines'


### PR DESCRIPTION
# Changes

When i added the option to specify the seed job agent image (in this commit : https://github.com/jenkinsci/kubernetes-operator/commit/56b65aed167fd4742c24cad49347006232343cdf) i just noticed that i forgot to update the CRD mentioned in the documentation : https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/installing-the-operator/

Sorry for the two part commit

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
CRD now allows the usage of seedJobAgentImage

```
