### PR TITLE
Download install-plugins.sh manually from remote

### DIFF
--- a/pkg/configuration/base/resources/scripts_configmap.go
+++ b/pkg/configuration/base/resources/scripts_configmap.go
@@ -13,6 +13,8 @@ import (
 )
 
 const installPluginsCommand = "install-plugins.sh"
+const installPluginsScriptRemoteLocation = "https://raw.githubusercontent.com/jenkinsci/docker/a9de6b9fb3a0601e51321bc0ea8c7638db2bf88f/install-plugins.sh"
+
 
 // bash scripts installs single jenkins plugin with specific version
 const installPluginsBashFmt = `#!/bin/bash -eu
@@ -265,6 +267,10 @@ chmod +x {{ .JenkinsHomePath }}/scripts/*.sh
 {{- $jenkinsHomePath := .JenkinsHomePath }}
 {{- $installPluginsCommand := .InstallPluginsCommand }}
 
+echo "Installing {{ $installPluginsCommand }}"
+curl {{ .InstallPluginsScriptRemoteLocation }} --output {{ $installPluginsCommand }}
+chmod +x {{ $installPluginsCommand }}
+
 echo "Installing plugins required by Operator - begin"
 cat > {{ .JenkinsHomePath }}/base-plugins << EOF
 {{ range $index, $plugin := .BasePlugins }}
@@ -302,19 +308,21 @@ func buildConfigMapTypeMeta() metav1.TypeMeta {
 
 func buildInitBashScript(jenkins *v1alpha2.Jenkins) (*string, error) {
 	data := struct {
-		JenkinsHomePath          string
-		InitConfigurationPath    string
-		InstallPluginsCommand    string
-		JenkinsScriptsVolumePath string
-		BasePlugins              []v1alpha2.Plugin
-		UserPlugins              []v1alpha2.Plugin
+		JenkinsHomePath          		string
+		InitConfigurationPath    		string
+		InstallPluginsCommand    		string
+		InstallPluginsScriptRemoteLocation 	string
+		JenkinsScriptsVolumePath 		string
+		BasePlugins              		[]v1alpha2.Plugin
+		UserPlugins              		[]v1alpha2.Plugin
 	}{
-		JenkinsHomePath:          getJenkinsHomePath(jenkins),
-		InitConfigurationPath:    jenkinsInitConfigurationVolumePath,
-		BasePlugins:              jenkins.Spec.Master.BasePlugins,
-		UserPlugins:              jenkins.Spec.Master.Plugins,
-		InstallPluginsCommand:    installPluginsCommand,
-		JenkinsScriptsVolumePath: JenkinsScriptsVolumePath,
+		JenkinsHomePath:          		getJenkinsHomePath(jenkins),
+		InitConfigurationPath:    		jenkinsInitConfigurationVolumePath,
+		BasePlugins:              		jenkins.Spec.Master.BasePlugins,
+		UserPlugins:              		jenkins.Spec.Master.Plugins,
+		InstallPluginsCommand:    		installPluginsCommand,
+		InstallPluginsScriptRemoteLocation: 	installPluginsScriptRemoteLocation,
+		JenkinsScriptsVolumePath: 		JenkinsScriptsVolumePath,
 	}
 
 	output, err := render.Render(initBashTemplate, data)


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

An attempt to fix https://github.com/jenkinsci/kubernetes-operator/issues/755

Manually download `install-plugins.sh` because original one has been removed from jenkins images

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
