### PR TITLE
proposed fix for #758 - migrating the jenkins-master container startup from install-plugins.sh to jenkins-plugin-cli and migrating /sbin/tini to /usr/bin/tini

### DIFF
--- a/pkg/configuration/base/resources/pod.go
+++ b/pkg/configuration/base/resources/pod.go
@@ -53,7 +53,7 @@ func GetJenkinsMasterContainerBaseCommand() []string {
 	return []string{
 		"bash",
 		"-c",
-		fmt.Sprintf("%s/%s && exec /sbin/tini -s -- /usr/local/bin/jenkins.sh",
+		fmt.Sprintf("%s/%s && exec /usr/bin/tini -s -- /usr/local/bin/jenkins.sh",
 			JenkinsScriptsVolumePath, InitScriptName),
 	}
 }

--- a/pkg/configuration/base/resources/scripts_configmap.go
+++ b/pkg/configuration/base/resources/scripts_configmap.go
@@ -12,7 +12,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const installPluginsCommand = "install-plugins.sh"
+const installPluginsCommand = "jenkins-plugin-cli"
 
 // bash scripts installs single jenkins plugin with specific version
 const installPluginsBashScript = `#!/bin/bash -eu
@@ -348,9 +348,9 @@ cat > {{ .JenkinsHomePath }}/base-plugins << EOF
 EOF
 
 if [[ -z "${OPENSHIFT_JENKINS_IMAGE_VERSION}" ]]; then
-  {{ $installPluginsCommand }} < {{ .JenkinsHomePath }}/base-plugins
+  {{ $installPluginsCommand }} -f {{ .JenkinsHomePath }}/base-plugins
 else
-  {{ $installPluginsCommand }} {{ .JenkinsHomePath }}/base-plugins
+  {{ $installPluginsCommand }} -f {{ .JenkinsHomePath }}/base-plugins
 fi
 echo "Installing plugins required by Operator - end"
 
@@ -361,9 +361,9 @@ cat > {{ .JenkinsHomePath }}/user-plugins << EOF
 {{ end }}
 EOF
 if [[ -z "${OPENSHIFT_JENKINS_IMAGE_VERSION}" ]]; then
-  {{ $installPluginsCommand }} < {{ .JenkinsHomePath }}/user-plugins
+  {{ $installPluginsCommand }} -f {{ .JenkinsHomePath }}/user-plugins
 else
-  {{ $installPluginsCommand }} {{ .JenkinsHomePath }}/user-plugins
+  {{ $installPluginsCommand }} -f {{ .JenkinsHomePath }}/user-plugins
 fi
 echo "Installing plugins required by user - end"
 `))

--- a/pkg/configuration/base/validate_test.go
+++ b/pkg/configuration/base/validate_test.go
@@ -905,7 +905,7 @@ func TestValidateJenkinsMasterContainerCommand(t *testing.T) {
 							Command: []string{
 								"bash",
 								"-c",
-								fmt.Sprintf("%s/%s && my-extra-command.sh && exec /sbin/tini -s -- /usr/local/bin/jenkins.sh",
+								fmt.Sprintf("%s/%s && my-extra-command.sh && exec /usr/bin/tini -s -- /usr/local/bin/jenkins.sh",
 									resources.JenkinsScriptsVolumePath, resources.InitScriptName),
 							},
 						},
@@ -929,7 +929,7 @@ func TestValidateJenkinsMasterContainerCommand(t *testing.T) {
 							Command: []string{
 								"bash",
 								"-c",
-								fmt.Sprintf("%s/%s && my-extra-command.sh && /sbin/tini -s -- /usr/local/bin/jenkins.sh",
+								fmt.Sprintf("%s/%s && my-extra-command.sh && /usr/bin/tini -s -- /usr/local/bin/jenkins.sh",
 									resources.JenkinsScriptsVolumePath, resources.InitScriptName),
 							},
 						},

--- a/website/content/en/docs/Developer Guide/_index.md
+++ b/website/content/en/docs/Developer Guide/_index.md
@@ -132,7 +132,8 @@ items:
       - command:
         - bash
         - -c
-        - /var/jenkins/scripts/init.sh && exec /sbin/tini -s -- /usr/local/bin/jenkins.sh
+        - /var/jenkins/scripts/init.sh
+        - exec /usr/bin/tini -s -- /usr/local/bin/jenkins.sh
         env:
         - name: JAVA_OPTS
           value: -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap


### PR DESCRIPTION
# Changes

Proposed changes for getting the `jenkins-jenkins` pod to start up the `jenkins-master` container on docker image `docker.io/jenkins/jenkins:2.366` and the operator on `virtuslab/jenkins-operator:v0.7.1`

I documented my notes in the issue:
https://github.com/jenkinsci/kubernetes-operator/issues/758#issuecomment-1233351254

Notes:
- I only tested this change with minikube 1.24 (I do not have virtualbox installed to test with the `make minikube-start` per the docs).
- I see explicit OpenShift if/else blocks that likely need to be reviewed (I do not have access to try the changes on an OpenShift cluster).
- I did not test the alpine or other jenkins docker images. The proposed path: `/usr/bin/tini` may not be consistent on other image OS'es.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [X] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._

## Reviewer Notes

This changes the `jenkins-master` container startup. This could impact a lot of users if it is incorrect.

# Release Notes