### PR TITLE
Add trap for the backup.sh script

### DIFF
--- a/backup/pvc/bin/backup.sh
+++ b/backup/pvc/bin/backup.sh
@@ -2,24 +2,36 @@
 
 set -eo pipefail
 
-[[ ! $# -eq 1 ]] && echo "Usage: $0 backup_number" && exit 1;
+[[ ! "${#}" -eq 1 ]] && echo "Usage: ${0} backup_number" && exit 1;
 [[ -z "${BACKUP_DIR}" ]] && echo "Required 'BACKUP_DIR' env not set" && exit 1;
 [[ -z "${JENKINS_HOME}" ]] && echo "Required 'JENKINS_HOME' env not set" && exit 1;
-BACKUP_TMP_DIR=$(mktemp -d)
 
-backup_number=$1
+BACKUP_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${BACKUP_TMP_DIR}"' EXIT
+
+backup_number="${1}"
 echo "Running backup"
 
 # config.xml in a job directory is a config file that shouldnt be backed up
 # config.xml in child directores is state that should. For example-
 # branches/myorg/branches/myrepo/branches/master/config.xml should be retained while
 # branches/myorg/config.xml should not
-tar -C ${JENKINS_HOME} -czf "${BACKUP_TMP_DIR}/${backup_number}.tar.gz" --exclude jobs/*/workspace* --no-wildcards-match-slash --anchored --exclude jobs/*/config.xml -c jobs && \
-mv ${BACKUP_TMP_DIR}/${backup_number}.tar.gz ${BACKUP_DIR}/${backup_number}.tar.gz
+tar \
+    --directory="${JENKINS_HOME}" \
+    --create \
+    --gzip \
+    --file "${BACKUP_TMP_DIR}/${backup_number}.tar.gz" \
+    --no-wildcards-match-slash \
+    --anchored \
+    --exclude jobs/*/workspace* \
+    --exclude jobs/*/config.xml \
+    jobs
 
-rm -r ${BACKUP_TMP_DIR}
+mv "${BACKUP_TMP_DIR}/${backup_number}.tar.gz" "${BACKUP_DIR}/${backup_number}.tar.gz"
 
-[[ ! -s ${BACKUP_DIR}/${backup_number}.tar.gz ]] && echo "backup file '${BACKUP_DIR}/${backup_number}.tar.gz' is empty" && exit 1;
+if [[ ! -s ${BACKUP_DIR}/${backup_number}.tar.gz ]] ; then
+    echo "backup file '${BACKUP_DIR}/${backup_number}.tar.gz' is empty" >&2
+    exit 1
+fi
 
 echo Done
-exit 0


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

It can happen the script exits unexpectedly in which case the resources will stay hanging there. With EXIT trap will be the temporary directory cleaned up on the script exit.

Extra refactoring changes were done to improve the readability of the script.

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user-facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._

## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS), and backward incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).