### PR TITLE
adding seedjobagentimage to jenkins chart

### DIFF
--- a/chart/jenkins-operator/templates/jenkins.yaml
+++ b/chart/jenkins-operator/templates/jenkins.yaml
@@ -158,4 +158,7 @@ spec:
   {{- with .Values.jenkins.seedJobs }}
   seedJobs: {{- toYaml . | nindent 4 }}
   {{- end }}
+  {{- if .Values.jenkins.seedJobAgentImage }}
+  seedJobAgentImage: {{ .Values.jenkins.seedJobAgentImage }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

The allowance to specify a seedjob agent image was introduced in #718 and #754.
While I specify the agent image in my values.yaml, the default agent image is still used.

This PR adds the seedjob agent image to the Jenkins chart.


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).
