### PR TITLE
Increase the memory limits for the kubernetes operator

### DIFF
--- a/deploy/all-in-one-v1alpha2.yaml
+++ b/deploy/all-in-one-v1alpha2.yaml
@@ -266,10 +266,10 @@ spec:
         resources:
           limits:
             cpu: 100m
-            memory: 30Mi
+            memory: 90Mi
           requests:
             cpu: 100m
-            memory: 20Mi
+            memory: 60Mi
         env:
           - name: WATCH_NAMESPACE
             valueFrom:


### PR DESCRIPTION
Increase the memory limits for the kubernetes operator

I found that with the previous limits, it would repeatedly be OOM-killed,
before I had even added any jenkins.

Fixes #773
