### PR TITLE
Fix broken link for configuring seed jobs

### DIFF
--- a/website/content/en/docs/Getting Started/latest/schema.md
+++ b/website/content/en/docs/Getting Started/latest/schema.md
@@ -109,7 +109,8 @@ Every single change here requires a pod restart.</p>
 <td>
 <em>(Optional)</em>
 <p>SeedJobs defines list of Jenkins Seed Job configurations
-More info: <a href="https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/configuration#configure-seed-jobs-and-pipelines">https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/configuration#configure-seed-jobs-and-pipelines</a></p>
+More info: <a href="https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/configuration#configure-seed-jobs-and-pipelines">
+  https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/configuring-seed-jobs-and-pipelines/</a></p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
# Changes

Link from Schema docs to seed job is broken

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

~~- [ ] Includes tests (if functionality changed/added)~~ N/A
- [x] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- Fix broken link on Operator Schema doc
```
