### PR TITLE
update image tag for `virtuslab/jenkins-operator-backup-pvc`

### DIFF
--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -200,7 +200,7 @@ jenkins:
 
     # image used by backup feature
     # By default using prebuilt backup PVC image by VirtusLab
-    image: virtuslab/jenkins-operator-backup-pvc:v0.1.0
+    image: virtuslab/jenkins-operator-backup-pvc:v0.1.1
 
     # containerName is backup container name
     containerName: backup

--- a/docs/docs/getting-started/latest/index.xml
+++ b/docs/docs/getting-started/latest/index.xml
@@ -641,7 +641,7 @@ Backup defines configuration of Jenkins backup.
                 &lt;code&gt;image&lt;/code&gt;
             &lt;/td&gt;
             &lt;td&gt;
-                virtuslab/jenkins-operator-backup-pvc:v0.0.8
+                virtuslab/jenkins-operator-backup-pvc:v0.1.1
             &lt;/td&gt;
             &lt;td&gt;
                 Image used by backup feature.

--- a/docs/docs/getting-started/latest/installing-the-operator/index.html
+++ b/docs/docs/getting-started/latest/installing-the-operator/index.html
@@ -1557,7 +1557,7 @@ Backup defines configuration of Jenkins backup.
                 <code>image</code>
             </td>
             <td>
-                virtuslab/jenkins-operator-backup-pvc:v0.0.8
+                virtuslab/jenkins-operator-backup-pvc:v0.1.1
             </td>
             <td>
                 Image used by backup feature.

--- a/docs/docs/index.xml
+++ b/docs/docs/index.xml
@@ -641,7 +641,7 @@ Backup defines configuration of Jenkins backup.
                 &lt;code&gt;image&lt;/code&gt;
             &lt;/td&gt;
             &lt;td&gt;
-                virtuslab/jenkins-operator-backup-pvc:v0.0.8
+                virtuslab/jenkins-operator-backup-pvc:v0.1.1
             &lt;/td&gt;
             &lt;td&gt;
                 Image used by backup feature.
@@ -1614,7 +1614,7 @@ Backup defines configuration of Jenkins backup.
                 &lt;code&gt;image&lt;/code&gt;
             &lt;/td&gt;
             &lt;td&gt;
-                virtuslab/jenkins-operator-backup-pvc:v0.0.8
+                virtuslab/jenkins-operator-backup-pvc:v0.1.1
             &lt;/td&gt;
             &lt;td&gt;
                 Image used by backup feature.

--- a/test/e2e/restorebackup_test.go
+++ b/test/e2e/restorebackup_test.go
@@ -157,7 +157,7 @@ func createJenkinsWithBackupAndRestoreConfigured(name, namespace string) *v1alph
 					},
 					{
 						Name:            containerName,
-						Image:           "virtuslab/jenkins-operator-backup-pvc:v0.1.0",
+						Image:           "virtuslab/jenkins-operator-backup-pvc:v0.1.1",
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Env: []corev1.EnvVar{
 							{

--- a/website/content/en/docs/Getting Started/latest/configuring-backup-and-restore.md
+++ b/website/content/en/docs/Getting Started/latest/configuring-backup-and-restore.md
@@ -71,7 +71,7 @@ spec:
             value: /jenkins-home
           - name: BACKUP_COUNT
             value: "3" # keep only the 2 most recent backups
-        image: virtuslab/jenkins-operator-backup-pvc:v0.1.0 # look at backup/pvc directory
+        image: virtuslab/jenkins-operator-backup-pvc:v0.1.1 # look at backup/pvc directory
         imagePullPolicy: IfNotPresent
         volumeMounts:
           - mountPath: /jenkins-home # Jenkins home volume

--- a/website/content/en/docs/Getting Started/latest/installing-the-operator.md
+++ b/website/content/en/docs/Getting Started/latest/installing-the-operator.md
@@ -638,7 +638,7 @@ Backup defines configuration of Jenkins backup.
                 <code>image</code>
             </td>
             <td>
-                virtuslab/jenkins-operator-backup-pvc:v0.0.8
+                virtuslab/jenkins-operator-backup-pvc:v0.1.1
             </td>
             <td>
                 Image used by backup feature.


### PR DESCRIPTION
# Changes

For the current operator version, update the scripts and documentation for image `virtuslab/jenkins-operator-backup-pvc` to tag `v0.1.1`. This is the most recent tag: https://hub.docker.com/r/virtuslab/jenkins-operator-backup-pvc/tags

Documentation for old versions of the operator is not updated.

I have not tested any of this.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes


