### PR TITLE
chore(operator): update operator version in master

### DIFF
--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -285,7 +285,7 @@ operator:
   replicaCount: 1
 
   # image is the name (and tag) of the Jenkins Operator image
-  image: quay.io/brokenpip3/jenkins-kubernetes-operator:a86b738a
+  image: virtuslab/jenkins-operator:60b8ee5
 
   # imagePullPolicy defines policy for pulling images
   imagePullPolicy: IfNotPresent


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

When this https://github.com/jenkinsci/kubernetes-operator/pull/784 was merged I forgot to remove the temporary operator img and put the official virtuslab one, this PR is revering that change by adding the latest operator img built 6 days ago.
When a new version will be officially tagged obv this will be superseeed by new official "operator tagged version".


# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._

