### PR TITLE
fix(backup): get-latest.sh, search for both .gz and .zstd

### DIFF
--- a/.github/workflows/auto-codespell.yml
+++ b/.github/workflows/auto-codespell.yml
@@ -18,4 +18,4 @@ jobs:
         with:
           check_filenames: true
           ignore_words_list: aks,ags,startin
-          skip: "*.js,package-lock.json,*.lock,*/Font-Awesome/*,*.toml,*.svg,*assets/vendor/bootstrap*"
+          skip: "*.js,package-lock.json,*.lock,*/Font-Awesome/*,*.toml,*.svg,*assets/vendor/bootstrap*,cert-manager.crds.yaml"

--- a/backup/pvc/bin/get-latest.sh
+++ b/backup/pvc/bin/get-latest.sh
@@ -3,7 +3,7 @@
 set -eo pipefail
 
 [[ -z "${BACKUP_DIR}" ]] && echo "Required 'BACKUP_DIR' env not set" && exit 1
-# Search for all the tar.* inside the backup dir to support the migration beetwen gzip vs zstd
+# Search for all the tar.* inside the backup dir to support the migration between gzip vs zstd
 latest=$(find ${BACKUP_DIR} -name '*.tar.*' -exec basename {} \; | sort -g | tail -n 1)
 
 if [[ "${latest}" == "" ]]; then

--- a/backup/pvc/bin/get-latest.sh
+++ b/backup/pvc/bin/get-latest.sh
@@ -3,8 +3,8 @@
 set -eo pipefail
 
 [[ -z "${BACKUP_DIR}" ]] && echo "Required 'BACKUP_DIR' env not set" && exit 1
-
-latest=$(find ${BACKUP_DIR} -name '*.tar.zstd' -exec basename {} \; | sort -g | tail -n 1)
+# Search for all the tar.* inside the backup dir to support the migration beetwen gzip vs zstd
+latest=$(find ${BACKUP_DIR} -name '*.tar.*' -exec basename {} \; | sort -g | tail -n 1)
 
 if [[ "${latest}" == "" ]]; then
   echo "-1"


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

`get-latest.sh` should support both gz and zstd to let the users migrate easily to zstd standard

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes
- Bug fixes
- Any changes in behavior

```
