### PR TITLE
Provides an Override to the WATCH_NAMESPACE env variable.

### DIFF
--- a/chart/jenkins-operator/templates/operator.yaml
+++ b/chart/jenkins-operator/templates/operator.yaml
@@ -57,6 +57,8 @@ spec:
             - name: WATCH_NAMESPACE
               {{- if .Values.jenkins.enabled }}
               value: {{ .Values.jenkins.namespace }}
+              {{- else if .Values.operator.watchNamespace }}
+              value: {{ .Values.operator.watchNamespace }}
               {{- else }}
               valueFrom:
                 fieldRef:

--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -308,6 +308,10 @@ operator:
   # fullnameOverride overrides the deployment name
   fullnameOverride: ""
 
+  # Select a different namespace to look for the Jenkins CR and deploy Jenkins in. Defaults to the same namespace as
+  # the operator.
+  # watchNamespace: "jenkins-namespace"
+
   resources: {}
   nodeSelector: {}
   tolerations: []

--- a/website/content/en/docs/Getting Started/latest/installing-the-operator.md
+++ b/website/content/en/docs/Getting Started/latest/installing-the-operator.md
@@ -133,7 +133,7 @@ Name of resource. The pod name will be <code>jenkins-&lt;name&gt;</code> (name w
 Namespace the resources will be deployed to. If omitted, the resources will be deployed to the same namespace as the operator.
 It's not recommended to use default namespace. Create new namespace for jenkins (e.g. <code>kubectl create -n jenkins</code>).
 
-<b>Note:</b> If the Jenkins instance is disabled, this propery will be ignored. Use the `operator.watchNamespace` property instead.
+<b>Note:</b> If the Jenkins instance is disabled, this property will be ignored. Use the `operator.watchNamespace` property instead.
 </td>
 </tr>
 <tr>

--- a/website/content/en/docs/Getting Started/latest/installing-the-operator.md
+++ b/website/content/en/docs/Getting Started/latest/installing-the-operator.md
@@ -127,11 +127,13 @@ Name of resource. The pod name will be <code>jenkins-&lt;name&gt;</code> (name w
 <code>namespace</code>
 </td>
 <td>
-default
+""
 </td>
 <td>
-Namespace the resources will be deployed to. It's not recommended to use default namespace.
-Create new namespace for jenkins (e.g. <code>kubectl create -n jenkins</code>)
+Namespace the resources will be deployed to. If omitted, the resources will be deployed to the same namespace as the operator.
+It's not recommended to use default namespace. Create new namespace for jenkins (e.g. <code>kubectl create -n jenkins</code>).
+
+<b>Note:</b> If the Jenkins instance is disabled, this propery will be ignored. Use the `operator.watchNamespace` property instead.
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
In case the Jenkins instance is disabled, this commit allows us to pick a different namespace for the deployment by configuring the operator object instead of the jenkins object.

# Changes

Adds a new operator.watchNamespace value that should be used in case jenkins.enabled is set to false. 
Updates and cleans up the documentation to reflect this change.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Describe any user facing changes here, or delete this block.

Examples of user facing changes:
- API changes: New operator.watchNamespace values.yaml configuration.
- Bug fixes #922 
- Any changes in behavior: None

```
