### PR TITLE
Fix: use consistent imagePullPolicy when enable Jenkins backup

### DIFF
--- a/chart/jenkins-operator/templates/jenkins.yaml
+++ b/chart/jenkins-operator/templates/jenkins.yaml
@@ -137,7 +137,7 @@ spec:
       {{- if .Values.jenkins.backup.enabled }}
       - name: {{ .Values.jenkins.backup.containerName }}
         image: {{ .Values.jenkins.backup.image }}
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: {{ .Values.jenkins.imagePullPolicy }} 
         {{- with .Values.jenkins.backup.resources }}
         resources: {{ toYaml . | nindent 10 }}
         {{- end }}


### PR DESCRIPTION
Update backup container `imagePullPolicy` to align with jenkins-master

Fix https://github.com/jenkinsci/kubernetes-operator/issues/914

`helm-test` pass log:

```
=== RUN   TestHelm
Running Suite: Controller Suite
===============================
Random Seed: 1701152304
Will run 3 of 3 specs

STEP: bootstrapping test environment
{"level":"info","ts":1701152304.5420983,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":":8080"}
Jenkins Controller with security validator When Jenkins CR contains plugins with security warnings 
  Denies creating a jenkins CR with a warning
  /workspaces/jenkins-operator/test/helm/helm_test.go:102
STEP: creating temporary namespace
{"level":"info","ts":1701152304.542624,"logger":"controller-runtime.manager","msg":"starting metrics server","path":"/metrics"}
STEP: Deploying the operator along with webhook and cert-manager
STEP: Waiting for the operator to fetch the plugin data
STEP: Denying a create request for a Jenkins custom resource
STEP: deleting temporary namespace

• [SLOW TEST:215.170 seconds]
Jenkins Controller with security validator
/workspaces/jenkins-operator/test/helm/helm_test.go:62
  When Jenkins CR contains plugins with security warnings
  /workspaces/jenkins-operator/test/helm/helm_test.go:101
    Denies creating a jenkins CR with a warning
    /workspaces/jenkins-operator/test/helm/helm_test.go:102
------------------------------
Jenkins Controller with security validator When Jenkins CR doesn't contain plugins with security warnings 
  Jenkins instance is successfully created
  /workspaces/jenkins-operator/test/helm/helm_test.go:124
STEP: creating temporary namespace
STEP: Deploying the operator along with webhook and cert-manager
STEP: Waiting for the operator to fetch the plugin data 
STEP: Creating a Jenkins custom resource with some plugins having security warnings but validation is turned off
STEP: waiting for Jenkins base configuration phase to complete
Jenkins pod is running
STEP: waiting for Jenkins user configuration phase to complete
Jenkins instance is up and ready
STEP: deleting temporary namespace

• [SLOW TEST:367.568 seconds]
Jenkins Controller with security validator
/workspaces/jenkins-operator/test/helm/helm_test.go:62
  When Jenkins CR doesn't contain plugins with security warnings
  /workspaces/jenkins-operator/test/helm/helm_test.go:123
    Jenkins instance is successfully created
    /workspaces/jenkins-operator/test/helm/helm_test.go:124
------------------------------
Jenkins Controller Deploys jenkins operator with helm charts with default values 
  Deploys Jenkins operator and configures default Jenkins instance
  /workspaces/jenkins-operator/test/helm/helm_test.go:39
STEP: creating temporary namespace
STEP: waiting for Jenkins base configuration phase to complete
Jenkins pod is running
STEP: waiting for Jenkins user configuration phase to complete
Jenkins instance is up and ready
STEP: deleting temporary namespace

• [SLOW TEST:190.561 seconds]
Jenkins Controller
/workspaces/jenkins-operator/test/helm/helm_test.go:21
  Deploys jenkins operator with helm charts with default values
  /workspaces/jenkins-operator/test/helm/helm_test.go:38
    Deploys Jenkins operator and configures default Jenkins instance
    /workspaces/jenkins-operator/test/helm/helm_test.go:39
------------------------------
STEP: tearing down the test environment


Ran 3 of 3 Specs in 773.732 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestHelm (773.73s)
PASS
ok      github.com/jenkinsci/kubernetes-operator/test/helm      773.761s
```

# Changes

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
Bug fixes: configure backup container imagePullPolicy to be the same as jenkins-master container.
```
