### PR TITLE
Fix: change default value for configurationAsCode and groovyScripts

### DIFF
--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -276,10 +276,10 @@ jenkins:
   # configuration is section where we can configure Jenkins instance
   # See https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/customization/ for details
   configuration:
-    configurationAsCode: {}
+    configurationAsCode: []
     #    - configMapName: jenkins-casc
     #      content: {}
-    groovyScripts: {}
+    groovyScripts: []
     #    - configMapName: jenkins-gs
     #      content: {}
 


### PR DESCRIPTION
<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

Change default value for configurationAsCode and groovyScripts to remove warning on Helm chart installation.
```
coalesce.go:286: warning: cannot overwrite table with non table for jenkins-operator.jenkins.configuration.configurationAsCode (map[])
coalesce.go:286: warning: cannot overwrite table with non table for jenkins-operator.jenkins.configuration.groovyScripts (map[])
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

