### PR TITLE
fix(backup): use atomic mv to create backup

### DIFF
--- a/website/content/en/docs/Getting Started/latest/configuring-backup-and-restore.md
+++ b/website/content/en/docs/Getting Started/latest/configuring-backup-and-restore.md
@@ -15,6 +15,12 @@ Backup and restore is done by a container sidecar.
 
 ### PVC
 
+#### PVC Storage Size
+
+Please ensure that the size of the PVC (Persistent Volume Claim) is sufficient to accommodate `BACKUP_COUNT` + `1` backup **tar.gz** archives.
+
+The additional **+1** space is necessary to facilitate the creation of backups on the same filesystem and to prevent backup file corruption during copying between different filesystems. For further details, please refer to pr [#1000](https://github.com/jenkinsci/kubernetes-operator/pull/1000).
+
 #### Create PVC
 
 Save to the file named pvc.yaml:


### PR DESCRIPTION
# Changes

use atomic mv to create backup to avoid broken unrestorable backups

## Details
```
% k exec jenkins-jenkins -c backup -- df -hT | grep -E "overlay|ext4"
overlay        overlay  110G   23G   88G  21% /
/dev/nvme2n1   ext4      64G   23G   42G  36% /backup
```
https://github.com/jenkinsci/kubernetes-operator/blob/cf49a4a28fbb1af5250031ce89b0a5267d81aca1/backup/pvc/bin/backup.sh#L8C1-L8C15
```
BACKUP_TMP_DIR=$(mktemp -d)
```
https://www.gnu.org/software/autogen/mktemp.html
```
      --tmpdir[=DIR]  interpret TEMPLATE relative to DIR.  If DIR is not
                        specified, use $TMPDIR if set, else /tmp.  With
                        this option, TEMPLATE must not be an absolute name.
                        Unlike with -t, TEMPLATE may contain slashes, but
                        mktemp creates only the final component
```
https://www.gnu.org/software/coreutils/manual/html_node/mv-invocation.html#mv-invocation
```
To move a file, mv ordinarily simply renames it. However, if renaming does not work because the destination's file system differs, mv falls back on copying as if by cp -a, then (assuming the copy succeeded) it removes the original.
```
To fix need just change this line to something like this
```
BACKUP_TMP_DIR=$(mktemp -d --tmpdir=${BACKUP_DIR})
```

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [ ] Includes docs (if user facing)
- [ ] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._


## Reviewer Notes

If API changes are included, additive changes must be approved by at least two [OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS) and backwards incompatible changes must be approved by [more than 50% of the OWNERS](https://github.com/jenkinsci/kubernetes-operator/blob/master/OWNERS).

# Release Notes

```
- backup creating on the same filesystem as BACKUP_DIR, to avoid broken backups during copy.
```
