### PR TITLE
feat: add option to restrict seed job agent to only run builds that m…

### DIFF
--- a/api/v1alpha2/jenkins_types.go
+++ b/api/v1alpha2/jenkins_types.go
@@ -22,6 +22,10 @@ type JenkinsSpec struct {
 	// +optional
 	SeedJobAgentImage string `json:"seedJobAgentImage,omitempty"`
 
+	// SeedJobRestrictJobsToLabel defines whether to set restrict node to label setting on the agent
+	// +optional
+	SeedJobRestrictJobsToLabel bool `json:"seedJobRestrictJobsToLabel,omitempty"`
+
 	// ValidateSecurityWarnings enables or disables validating potential security warnings in Jenkins plugins via admission webhooks.
 	//+optional
 	ValidateSecurityWarnings bool `json:"validateSecurityWarnings,omitempty"`

--- a/chart/jenkins-operator/README.md
+++ b/chart/jenkins-operator/README.md
@@ -88,6 +88,7 @@ Kubernetes native operator which fully manages Jenkins on Kubernetes
 | jenkins.securityContext.fsGroup | int | `1000` |  |
 | jenkins.securityContext.runAsUser | int | `1000` |  |
 | jenkins.seedJobAgentImage | string | `""` |  |
+| jenkins.seedJobRestrictJobsToLabel | boolean | `false` |  |
 | jenkins.seedJobs | list | `[]` |  |
 | jenkins.serviceAccount.annotations | object | `{}` |  |
 | jenkins.terminationGracePeriodSeconds | int | `30` |  |

--- a/chart/jenkins-operator/crds/jenkins-crd.yaml
+++ b/chart/jenkins-operator/crds/jenkins-crd.yaml
@@ -3131,6 +3131,10 @@ spec:
                   by the seed job agent. If not defined jenkins/inbound-agent:4.9-1
                   will be used.
                 type: string
+              seedJobRestrictJobsToLabel:
+                description: SeedJobRestrictJobsToLabel defines whether the seed job agent
+                  will be restricted to only running jobs with the seed job label.
+                type: boolean
               seedJobs:
                 description: 'SeedJobs defines list of Jenkins Seed Job configurations
                   More info: https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/configuration#configure-seed-jobs-and-pipelines'

--- a/chart/jenkins-operator/templates/jenkins.yaml
+++ b/chart/jenkins-operator/templates/jenkins.yaml
@@ -171,4 +171,7 @@ spec:
   {{- if .Values.jenkins.seedJobAgentImage }}
   seedJobAgentImage: {{ .Values.jenkins.seedJobAgentImage }}
   {{- end }}
+  {{- if .Values.jenkins.seedJobRestrictJobsToLabel }}
+  seedJobRestrictJobsToLabel: {{ .Values.jenkins.seedJobRestrictJobsToLabel }}
+  {{- end }}
 {{- end }}

--- a/chart/jenkins-operator/values.yaml
+++ b/chart/jenkins-operator/values.yaml
@@ -145,6 +145,9 @@ jenkins:
   # SeedJobAgentImage defines the image that will be used by the seed job agent. If not defined jenkins/inbound-agent:3248.v65ecb_254c298-6 will be used.
   seedJobAgentImage: ""
 
+  # SeedJobRestrictJobsToLabel defines whether the seed job agent will be restricted to only running jobs with the seed job label.
+  seedJobRestrictJobsToLabel: false
+
   # Resource limit/request for Jenkins
   # See https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/ for details
   resources:

--- a/config/crd/bases/jenkins.io_jenkins.yaml
+++ b/config/crd/bases/jenkins.io_jenkins.yaml
@@ -3135,6 +3135,10 @@ spec:
                   by the seed job agent. If not defined jenkins/inbound-agent:4.9-1
                   will be used.
                 type: string
+              seedJobRestrictJobsToLabel:
+                description: SeedJobRestrictJobsToLabel defines whether the seed job agent
+                  will be restricted to only running jobs with the seed job label.
+                type: boolean
               seedJobs:
                 description: 'SeedJobs defines list of Jenkins Seed Job configurations
                   More info: https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/configuration#configure-seed-jobs-and-pipelines'

--- a/deploy/crds/jenkins.io_jenkins_crd.yaml
+++ b/deploy/crds/jenkins.io_jenkins_crd.yaml
@@ -3131,6 +3131,10 @@ spec:
                   by the seed job agent. If not defined jenkins/inbound-agent:4.9-1
                   will be used.
                 type: string
+              seedJobRestrictJobsToLabel:
+                description: SeedJobRestrictJobsToLabel defines whether the seed job agent
+                  will be restricted to only running jobs with the seed job label.
+                type: boolean
               seedJobs:
                 description: 'SeedJobs defines list of Jenkins Seed Job configurations
                   More info: https://jenkinsci.github.io/kubernetes-operator/docs/getting-started/latest/configuration#configure-seed-jobs-and-pipelines'

--- a/pkg/configuration/user/seedjobs/seedjobs.go
+++ b/pkg/configuration/user/seedjobs/seedjobs.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 	"text/template"
 
+	"github.com/go-logr/logr"
 	"github.com/jenkinsci/kubernetes-operator/api/v1alpha2"
 	"github.com/jenkinsci/kubernetes-operator/internal/render"
 	jenkinsclient "github.com/jenkinsci/kubernetes-operator/pkg/client"
@@ -17,8 +18,6 @@ import (
 	"github.com/jenkinsci/kubernetes-operator/pkg/groovy"
 	"github.com/jenkinsci/kubernetes-operator/pkg/log"
 	"github.com/jenkinsci/kubernetes-operator/pkg/notifications/reason"
-
-	"github.com/go-logr/logr"
 	stackerr "github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -48,7 +47,8 @@ const (
 	// DefaultAgentImage is the default image used for the seed-job agent
 	defaultAgentImage = "jenkins/inbound-agent:3248.v65ecb_254c298-6"
 
-	creatingGroovyScriptName = "seed-job-groovy-script.groovy"
+	creatingGroovyScriptName  = "seed-job-groovy-script.groovy"
+	agentModeGroovyScriptName = "seed-job-agent-mode-groovy-script.groovy"
 
 	homeVolumeName = "home"
 	homeVolumePath = "/home/jenkins/agent"
@@ -56,6 +56,18 @@ const (
 	workspaceVolumeName = "workspace"
 	workspaceVolumePath = "/home/jenkins/workspace"
 )
+
+var seedAgentSetModeScriptTemplate = template.Must(template.New(agentModeGroovyScriptName).Parse(`
+import hudson.model.*
+import jenkins.model.*
+import hudson.slaves.*
+import hudson.slaves.EnvironmentVariablesNodeProperty.Entry
+import jenkins.model.Jenkins;
+
+Jenkins jenkins = Jenkins.instance
+def agent = jenkins.getNode("{{.AgentName}}")
+agent.setMode(Node.Mode.EXCLUSIVE)
+`))
 
 var seedJobGroovyScriptTemplate = template.Must(template.New(creatingGroovyScriptName).Parse(`
 import hudson.model.FreeStyleProject;
@@ -379,6 +391,18 @@ func (s *seedJobs) createAgent(jenkinsClient jenkinsclient.Jenkins, k8sClient cl
 		}
 	} else if err != nil {
 		return stackerr.WithStack(err)
+	}
+
+	if s.Configuration.Jenkins.Spec.SeedJobRestrictJobsToLabel {
+		data := struct{ AgentName string }{AgentName: agentName}
+		setAgentModeScript, err := render.Render(seedAgentSetModeScriptTemplate, data)
+		if err != nil {
+			return err
+		}
+		_, err = jenkinsClient.ExecuteScript(setAgentModeScript)
+		if err != nil {
+			return err
+		}
 	}
 
 	secret, err := jenkinsClient.GetNodeSecret(agentName)


### PR DESCRIPTION
…atch the node label

Fixes #1014

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

# Changes

This change adds a new flag for telling the operator to spawn the seed jobs agent with the EXCLUSIVE mode set such that it will only run builds for jobs that match its label.

# Submitter Checklist

These are the criteria that every PR should meet, please check them off as you
review them:

- [ ] Includes tests (if functionality changed/added)
- [x] Includes docs (if user facing)
- [x] Commit messages follow [commit message best practices](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md#commit-messages)

_See [the contribution guide](https://github.com/jenkinsci/kubernetes-operator/blob/master/CONTRIBUTING.md) for more details._
